### PR TITLE
Prevents sending excessive value updates to the native side

### DIFF
--- a/packages/zefyr/CHANGELOG.md
+++ b/packages/zefyr/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.1
+
+* Fixed: Prevent sending excessive value updates to the native side
+  which cause race conditions (#12).
+
 ## 0.1.0
 
 *  Initial release.

--- a/packages/zefyr/example/lib/main.dart
+++ b/packages/zefyr/example/lib/main.dart
@@ -63,11 +63,11 @@ class _MyHomePageState extends State<MyHomePage> {
   Widget build(BuildContext context) {
     final theme = new ZefyrThemeData(
       toolbarTheme: ZefyrToolbarTheme.fallback(context).copyWith(
-            color: Colors.grey.shade800,
-            toggleColor: Colors.grey.shade900,
-            iconColor: Colors.white,
-            disabledIconColor: Colors.grey.shade500,
-          ),
+        color: Colors.grey.shade800,
+        toggleColor: Colors.grey.shade900,
+        iconColor: Colors.white,
+        disabledIconColor: Colors.grey.shade500,
+      ),
     );
 
     final done = _editing

--- a/packages/zefyr/pubspec.yaml
+++ b/packages/zefyr/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zefyr
 description: Rich text editor for Flutter.
-version: 0.1.0
+version: 0.1.1
 author: Anatoly Pulyaevskiy <anatoly.pulyaevskiy@gmail.com>
 homepage: https://github.com/pulyaevskiy/zefyr
 


### PR DESCRIPTION
Fixes #11.

This addresses two issues:

1. Ensures that `composing` range is always set to the last known value for data sent to the native side.
2. Prevents sending remote updates if current value (including composing range) is the same the the last known value.

cc @stemuk