### PR TITLE
Remove highlightElevation from RawZefyrButton

### DIFF
--- a/packages/zefyr/lib/src/widgets/buttons.dart
+++ b/packages/zefyr/lib/src/widgets/buttons.dart
@@ -186,6 +186,7 @@ class RawZefyrButton extends StatelessWidget {
       child: RawMaterialButton(
         shape: RoundedRectangleBorder(borderRadius: radius),
         elevation: 0.0,
+        highlightElevation: 0.0,
         fillColor: color,
         constraints: constraints,
         onPressed: onPressed,


### PR DESCRIPTION
## Issue
Currently, there is a pretty intense elevation of active toolbar buttons during a long-press. The elevation is also visible for a short period of time when the user toggles an active button to become inactive. 

This behavior does not look intended and does not seem coherent with the perception of a simple on/off toggle button (suddenly there is a third dimension out of nowhere).

## Fix
The PR explicitly sets the `highlightElevation` of the underlying `RawMaterialButton` to `0`.