### PR TITLE
Replace cupertinoTextSelectionControls with materialTextSelectionControls

### DIFF
--- a/packages/zefyr/lib/src/widgets/editable_text.dart
+++ b/packages/zefyr/lib/src/widgets/editable_text.dart
@@ -1,7 +1,7 @@
 // Copyright (c) 2018, the Zefyr project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:notus/notus.dart';
 
@@ -117,7 +117,7 @@ class _ZefyrEditableTextState extends State<ZefyrEditableText>
     if (widget.enabled) {
       layers.add(ZefyrSelectionOverlay(
         controller: widget.controller,
-        controls: cupertinoTextSelectionControls,
+        controls: materialTextSelectionControls,
         overlay: overlay,
       ));
     }


### PR DESCRIPTION
Fix #57.
I think materialTextSelectionControls is much better than cupertinoTextSelectionControls. Please see: https://github.com/flutter/flutter/issues/22624