### PR TITLE
export ZefyrScopeAccess

### DIFF
--- a/packages/zefyr/lib/zefyr.dart
+++ b/packages/zefyr/lib/zefyr.dart
@@ -22,7 +22,7 @@ export 'src/widgets/list.dart';
 export 'src/widgets/paragraph.dart';
 export 'src/widgets/quote.dart';
 export 'src/widgets/scaffold.dart';
-export 'src/widgets/scope.dart' hide ZefyrScopeAccess;
+export 'src/widgets/scope.dart';
 export 'src/widgets/selection.dart' hide SelectionHandleDriver;
 export 'src/widgets/theme.dart';
 export 'src/widgets/toolbar.dart';


### PR DESCRIPTION
This is required to use ZefyrEditableText without ZefyrEditor