### PR TITLE
Removed dependency on image_picker plugin

### DIFF
--- a/doc/images.md
+++ b/doc/images.md
@@ -1,40 +1,54 @@
 ## Images
 
-> Note that described API is considered experimental and is likely to be
+> Note that Image API is considered experimental and is likely to be
 > changed in backward incompatible ways. If this happens all changes will be
 > described in detail in the changelog to simplify upgrading.
 
-Zefyr (and Notus) supports embedded images. In order to handle images in
+Zefyr supports embedding images. In order to handle images in
 your application you need to implement `ZefyrImageDelegate` interface which
 looks like this:
 
 ```dart
 abstract class ZefyrImageDelegate<S> {
-  /// Builds image widget for specified [imageSource] and [context].
-  Widget buildImage(BuildContext context, String imageSource);
+  /// Unique key to identify camera source.
+  S get cameraSource;
+
+  /// Unique key to identify gallery source.
+  S get gallerySource;
+
+  /// Builds image widget for specified image [key].
+  ///
+  /// The [key] argument contains value which was previously returned from
+  /// [pickImage].
+  Widget buildImage(BuildContext context, String key);
 
   /// Picks an image from specified [source].
   ///
   /// Returns unique string key for the selected image. Returned key is stored
   /// in the document.
+  ///
+  /// Depending on your application returned key may represent a path to
+  /// an image file on user's device, an HTTP link, or an identifier generated
+  /// by a file hosting service like AWS S3 or Google Drive.
   Future<String> pickImage(S source);
 }
 ```
 
-Zefyr comes with default implementation which exists mostly to provide an
-example and a starting point for your own version.
+There is no default implementation of this interface since resolving image
+sources is always application-specific.
 
-It is recommended to always have your own implementation specific to your
-application.
+> Note that prior to 0.7.0 Zefyr did provide simple default implementation of
+> `ZefyrImageDelegate` however it was removed as it introduced unnecessary
+> dependency on `image_picker` plugin.
 
 ### Implementing ZefyrImageDelegate
+
+For this example we will use [image_picker](https://pub.dev/packages/image_picker)
+plugin which allows us to select images from device's camera or photo gallery.
 
 Let's start from the `pickImage` method:
 
 ```dart
-// Currently Zefyr depends on image_picker plugin to show camera or image gallery.
-// (note that in future versions this may change so that users can choose their
-// own plugin and define custom sources)
 import 'package:image_picker/image_picker.dart';
 
 class MyAppZefyrImageDelegate implements ZefyrImageDelegate<ImageSource> {
@@ -53,17 +67,17 @@ camera or gallery), handling result of selection and returning a string value
 which essentially serves as an identifier for the image.
 
 Returned value is stored in the document Delta and later on used to build the
-appropriate `Widget`.
+appropriate image widget.
 
 It is up to the developer to define what this value represents.
 
 In the above example we simply return a full path to the file on user's device,
 e.g. `file:///Users/something/something/image.jpg`. Some other examples
-may include a web link, `https://myapp.com/images/some.jpg` or just some
-arbitrary string like an ID.
+may include a web link, `https://myapp.com/images/some.jpg` or an
+arbitrary string like an identifier of an image in a cloud storage like AWS S3.
 
 For instance, if you upload files to your server you can initiate this task
-in `pickImage`, for instance:
+in `pickImage` as follows:
 
 ```dart
 class MyAppZefyrImageDelegate implements ZefyrImageDelegate<ImageSource> {
@@ -84,7 +98,7 @@ class MyAppZefyrImageDelegate implements ZefyrImageDelegate<ImageSource> {
 
 Next we need to implement `buildImage`. This method takes `imageSource` argument
 which contains that same string you returned from `pickImage`. Here you can
-use this value to create a Flutter `Widget` which renders the image. Normally
+use this value to create a Flutter widget which renders the image. Normally
 you would return the standard `Image` widget from this method, but it is not
 a requirement. You are free to create a custom widget which, for instance,
 shows progress of upload operation that you initiated in the `pickImage` call.
@@ -97,12 +111,58 @@ class MyAppZefyrImageDelegate implements ZefyrImageDelegate<ImageSource> {
   // ...
 
   @override
-  Widget buildImage(BuildContext context, String imageSource) {
-    final file = new File.fromUri(Uri.parse(imageSource));
-    /// Create standard [FileImage] provider. If [imageSource] was an HTTP link
+  Widget buildImage(BuildContext context, String key) {
+    final file = File.fromUri(Uri.parse(key));
+    /// Create standard [FileImage] provider. If [key] was an HTTP link
     /// we could use [NetworkImage] instead.
-    final image = new FileImage(file);
-    return new Image(image: image);
+    final image = FileImage(file);
+    return Image(image: image);
+  }
+}
+```
+
+There is two more overrides we need to implement which configure source types
+used by Zefyr toolbar:
+
+```dart
+class MyAppZefyrImageDelegate implements ZefyrImageDelegate<ImageSource> {
+  // ...
+  @override
+  ImageSource get cameraSource => ImageSource.camera;
+
+  @override
+  ImageSource get gallerySource => ImageSource.gallery;
+}
+```
+
+Now our image delegate is ready to be used by Zefyr so the last step is to
+pass it to Zefyr editor:
+
+```dart
+import 'package:zefyr/zefyr.dart'
+
+class MyAppPageState extends State<MyAppPage> {
+  FocueNode _focusNode = FocusNode();
+  ZefyrController _controller;
+
+  // ...
+
+  @override
+  Widget build(BuildContext context) {
+    final editor = new ZefyrEditor(
+      focusNode: _focusNode,
+      controller: _controller,
+      imageDelegate: MyAppZefyrImageDelegate(),
+    );
+
+    // ... do more with this page's layout
+
+    return ZefyrScaffold(
+      child: Container(
+        // ... customize
+        child: editor,
+      )
+    );
   }
 }
 ```

--- a/packages/zefyr/CHANGELOG.md
+++ b/packages/zefyr/CHANGELOG.md
@@ -10,6 +10,14 @@ This release contains breaking changes.
     - `ZefyrMode.view`: the same as `enabled: false`, read-only.
 * Added optional `selectionControls` field to `ZefyrEditor` and `ZefyrEditableText`. If not provided
   then by default uses platform-specific implementation.
+* Added support for "selectAll" action in selection toolbar.
+* Breaking change: removed `ZefyrDefaultImageDelegate` as well as dependency on
+  `image_picker` plugin. Users are required to provide their own implementation. If image delegate
+  is not provided then image toolbar button is disabled.
+* Breaking change: added `ZefyrImageDelegate.cameraSource` and `ZefyrImageDelegate.gallerySource`
+  fields. For users of `image_picker` plugin these should return `ImageSource.camera` and
+  `ImageSource.gallery` respectively. See documentation on implementing image support for more
+  details.
 
 ## 0.6.0
 

--- a/packages/zefyr/example/lib/src/form.dart
+++ b/packages/zefyr/example/lib/src/form.dart
@@ -1,7 +1,12 @@
+// Copyright (c) 2018, the Zefyr project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 import 'package:zefyr/zefyr.dart';
 
 import 'full_page.dart';
+import 'images.dart';
 
 class FormEmbeddedScreen extends StatefulWidget {
   @override

--- a/packages/zefyr/example/lib/src/full_page.dart
+++ b/packages/zefyr/example/lib/src/full_page.dart
@@ -1,9 +1,15 @@
+// Copyright (c) 2018, the Zefyr project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:quill_delta/quill_delta.dart';
 import 'package:zefyr/zefyr.dart';
+
+import 'images.dart';
 
 class ZefyrLogo extends StatelessWidget {
   @override
@@ -104,22 +110,5 @@ class _FullPageEditorScreenState extends State<FullPageEditorScreen> {
     setState(() {
       _editing = false;
     });
-  }
-}
-
-/// Custom image delegate used by this example to load image from application
-/// assets.
-///
-/// Default image delegate only supports [FileImage]s.
-class CustomImageDelegate extends ZefyrDefaultImageDelegate {
-  @override
-  Widget buildImage(BuildContext context, String imageSource) {
-    // We use custom "asset" scheme to distinguish asset images from other files.
-    if (imageSource.startsWith('asset://')) {
-      final asset = new AssetImage(imageSource.replaceFirst('asset://', ''));
-      return new Image(image: asset);
-    } else {
-      return super.buildImage(context, imageSource);
-    }
   }
 }

--- a/packages/zefyr/example/lib/src/images.dart
+++ b/packages/zefyr/example/lib/src/images.dart
@@ -1,0 +1,40 @@
+// Copyright (c) 2018, the Zefyr project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:zefyr/zefyr.dart';
+
+/// Custom image delegate used by this example to load image from application
+/// assets.
+class CustomImageDelegate implements ZefyrImageDelegate<ImageSource> {
+  @override
+  ImageSource get cameraSource => ImageSource.camera;
+
+  @override
+  ImageSource get gallerySource => ImageSource.gallery;
+
+  @override
+  Future<String> pickImage(ImageSource source) async {
+    final file = await ImagePicker.pickImage(source: source);
+    if (file == null) return null;
+    return file.uri.toString();
+  }
+
+  @override
+  Widget buildImage(BuildContext context, String key) {
+    // We use custom "asset" scheme to distinguish asset images from other files.
+    if (key.startsWith('asset://')) {
+      final asset = AssetImage(key.replaceFirst('asset://', ''));
+      return Image(image: asset);
+    } else {
+      // Otherwise assume this is a file stored locally on user's device.
+      final file = File.fromUri(Uri.parse(key));
+      final image = FileImage(file);
+      return new Image(image: image);
+    }
+  }
+}

--- a/packages/zefyr/example/lib/src/view.dart
+++ b/packages/zefyr/example/lib/src/view.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2018, the Zefyr project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
@@ -5,6 +9,7 @@ import 'package:quill_delta/quill_delta.dart';
 import 'package:zefyr/zefyr.dart';
 
 import 'full_page.dart';
+import 'images.dart';
 
 class ViewScreen extends StatefulWidget {
   @override
@@ -66,22 +71,5 @@ class _ViewScreen extends State<ViewScreen> {
         ),
       ),
     );
-  }
-}
-
-/// Custom image delegate used by this example to load image from application
-/// assets.
-///
-/// Default image delegate only supports [FileImage]s.
-class CustomImageDelegate extends ZefyrDefaultImageDelegate {
-  @override
-  Widget buildImage(BuildContext context, String imageSource) {
-    // We use custom "asset" scheme to distinguish asset images from other files.
-    if (imageSource.startsWith('asset://')) {
-      final asset = new AssetImage(imageSource.replaceFirst('asset://', ''));
-      return new Image(image: asset);
-    } else {
-      return super.buildImage(context, imageSource);
-    }
   }
 }

--- a/packages/zefyr/example/pubspec.yaml
+++ b/packages/zefyr/example/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
+  image_picker: ^0.6.1
   zefyr:
     path: ../
 

--- a/packages/zefyr/lib/src/widgets/buttons.dart
+++ b/packages/zefyr/lib/src/widgets/buttons.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:image_picker/image_picker.dart';
 import 'package:notus/notus.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -279,14 +278,16 @@ class _ImageButtonState extends State<ImageButton> {
 
   void _pickFromCamera() async {
     final editor = ZefyrToolbar.of(context).editor;
-    final image = await editor.imageDelegate.pickImage(ImageSource.camera);
+    final image =
+        await editor.imageDelegate.pickImage(editor.imageDelegate.cameraSource);
     if (image != null)
       editor.formatSelection(NotusAttribute.embed.image(image));
   }
 
   void _pickFromGallery() async {
     final editor = ZefyrToolbar.of(context).editor;
-    final image = await editor.imageDelegate.pickImage(ImageSource.gallery);
+    final image = await editor.imageDelegate
+        .pickImage(editor.imageDelegate.gallerySource);
     if (image != null)
       editor.formatSelection(NotusAttribute.embed.image(image));
   }

--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -121,7 +121,7 @@ class _ZefyrEditorState extends State<ZefyrEditor> {
   @override
   void initState() {
     super.initState();
-    _imageDelegate = widget.imageDelegate ?? new ZefyrDefaultImageDelegate();
+    _imageDelegate = widget.imageDelegate;
   }
 
   @override
@@ -131,7 +131,7 @@ class _ZefyrEditorState extends State<ZefyrEditor> {
     _scope.controller = widget.controller;
     _scope.focusNode = widget.focusNode;
     if (widget.imageDelegate != oldWidget.imageDelegate) {
-      _imageDelegate = widget.imageDelegate ?? new ZefyrDefaultImageDelegate();
+      _imageDelegate = widget.imageDelegate;
       _scope.imageDelegate = _imageDelegate;
     }
   }

--- a/packages/zefyr/lib/src/widgets/image.dart
+++ b/packages/zefyr/lib/src/widgets/image.dart
@@ -2,42 +2,41 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import 'dart:async';
-import 'dart:io';
 import 'dart:math' as math;
 import 'dart:ui' as ui;
 
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
+import 'package:meta/meta.dart';
 import 'package:notus/notus.dart';
-import 'package:image_picker/image_picker.dart';
 
 import 'editable_box.dart';
 
+/// Provides interface for embedding images into Zefyr editor.
+// TODO: allow configuring image sources and related toolbar buttons.
+@experimental
 abstract class ZefyrImageDelegate<S> {
-  /// Builds image widget for specified [imageSource] and [context].
-  Widget buildImage(BuildContext context, String imageSource);
+  /// Unique key to identify camera source.
+  S get cameraSource;
+
+  /// Unique key to identify gallery source.
+  S get gallerySource;
+
+  /// Builds image widget for specified image [key].
+  ///
+  /// The [key] argument contains value which was previously returned from
+  /// [pickImage] method.
+  Widget buildImage(BuildContext context, String key);
 
   /// Picks an image from specified [source].
   ///
   /// Returns unique string key for the selected image. Returned key is stored
   /// in the document.
+  ///
+  /// Depending on your application returned key may represent a path to
+  /// an image file on user's device, an HTTP link, or an identifier generated
+  /// by a file hosting service like AWS S3 or Google Drive.
   Future<String> pickImage(S source);
-}
-
-class ZefyrDefaultImageDelegate implements ZefyrImageDelegate<ImageSource> {
-  @override
-  Widget buildImage(BuildContext context, String imageSource) {
-    final file = new File.fromUri(Uri.parse(imageSource));
-    final image = new FileImage(file);
-    return new Image(image: image);
-  }
-
-  @override
-  Future<String> pickImage(ImageSource source) async {
-    final file = await ImagePicker.pickImage(source: source);
-    if (file == null) return null;
-    return file.uri.toString();
-  }
 }
 
 class ZefyrImage extends StatefulWidget {

--- a/packages/zefyr/lib/src/widgets/scope.dart
+++ b/packages/zefyr/lib/src/widgets/scope.dart
@@ -25,11 +25,9 @@ class ZefyrScope extends ChangeNotifier {
   /// Creates a view-only scope.
   ///
   /// Normally used in [ZefyrView].
-  ZefyrScope.view({
-    @required ZefyrMode mode,
-    @required ZefyrImageDelegate imageDelegate,
-  })  : assert(imageDelegate != null),
-        isEditable = false,
+  ZefyrScope.view({ZefyrImageDelegate imageDelegate})
+      : isEditable = false,
+        _mode = ZefyrMode.view,
         _imageDelegate = imageDelegate;
 
   /// Creates editable scope.
@@ -38,12 +36,11 @@ class ZefyrScope extends ChangeNotifier {
   ZefyrScope.editable({
     @required ZefyrMode mode,
     @required ZefyrController controller,
-    @required ZefyrImageDelegate imageDelegate,
     @required FocusNode focusNode,
     @required FocusScopeNode focusScope,
+    ZefyrImageDelegate imageDelegate,
   })  : assert(mode != null),
         assert(controller != null),
-        assert(imageDelegate != null),
         assert(focusNode != null),
         assert(focusScope != null),
         isEditable = true,
@@ -69,7 +66,6 @@ class ZefyrScope extends ChangeNotifier {
   ZefyrImageDelegate _imageDelegate;
   ZefyrImageDelegate get imageDelegate => _imageDelegate;
   set imageDelegate(ZefyrImageDelegate value) {
-    assert(value != null);
     if (_imageDelegate != value) {
       _imageDelegate = value;
       notifyListeners();

--- a/packages/zefyr/lib/src/widgets/toolbar.dart
+++ b/packages/zefyr/lib/src/widgets/toolbar.dart
@@ -259,7 +259,7 @@ class ZefyrToolbarState extends State<ZefyrToolbar>
       buildButton(context, ZefyrToolbarAction.quote),
       buildButton(context, ZefyrToolbarAction.code),
       buildButton(context, ZefyrToolbarAction.horizontalRule),
-      ImageButton(),
+      if (editor.imageDelegate != null) ImageButton(),
     ];
     return buttons;
   }

--- a/packages/zefyr/lib/src/widgets/view.dart
+++ b/packages/zefyr/lib/src/widgets/view.dart
@@ -9,7 +9,6 @@ import 'code.dart';
 import 'common.dart';
 import 'image.dart';
 import 'list.dart';
-import 'mode.dart';
 import 'paragraph.dart';
 import 'quote.dart';
 import 'scope.dart';
@@ -37,10 +36,7 @@ class ZefyrViewState extends State<ZefyrView> {
   @override
   void initState() {
     super.initState();
-    _scope = ZefyrScope.view(
-      mode: ZefyrMode.view,
-      imageDelegate: widget.imageDelegate,
-    );
+    _scope = ZefyrScope.view(imageDelegate: widget.imageDelegate);
   }
 
   @override

--- a/packages/zefyr/pubspec.yaml
+++ b/packages/zefyr/pubspec.yaml
@@ -5,14 +5,13 @@ author: Anatoly Pulyaevskiy <anatoly.pulyaevskiy@gmail.com>
 homepage: https://github.com/memspace/zefyr
 
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: '>=2.2.2 <3.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
   collection: ^1.14.6
   url_launcher: ^5.0.0
-  image_picker: ^0.5.0
   quill_delta: ^1.0.0-dev.1.0
   notus: ^0.1.0
   meta: ^1.1.0

--- a/packages/zefyr/test/testing.dart
+++ b/packages/zefyr/test/testing.dart
@@ -22,6 +22,7 @@ class EditorSandBox {
     NotusDocument document,
     ZefyrThemeData theme,
     bool autofocus: false,
+    ZefyrImageDelegate imageDelegate,
   }) {
     focusNode ??= FocusNode();
     document ??= NotusDocument.fromDelta(delta);
@@ -31,6 +32,7 @@ class EditorSandBox {
       controller: controller,
       focusNode: focusNode,
       autofocus: autofocus,
+      imageDelegate: imageDelegate,
     );
 
     if (theme != null) {
@@ -115,12 +117,17 @@ class EditorSandBox {
 }
 
 class _ZefyrSandbox extends StatefulWidget {
-  const _ZefyrSandbox(
-      {Key key, this.controller, this.focusNode, this.autofocus})
-      : super(key: key);
+  const _ZefyrSandbox({
+    Key key,
+    this.controller,
+    this.focusNode,
+    this.autofocus,
+    this.imageDelegate,
+  }) : super(key: key);
   final ZefyrController controller;
   final FocusNode focusNode;
   final bool autofocus;
+  final ZefyrImageDelegate imageDelegate;
 
   @override
   _ZefyrSandboxState createState() => _ZefyrSandboxState();
@@ -136,6 +143,7 @@ class _ZefyrSandboxState extends State<_ZefyrSandbox> {
       focusNode: widget.focusNode,
       mode: _enabled ? ZefyrMode.edit : ZefyrMode.view,
       autofocus: widget.autofocus,
+      imageDelegate: widget.imageDelegate,
     );
   }
 

--- a/packages/zefyr/test/widgets/buttons_test.dart
+++ b/packages/zefyr/test/widgets/buttons_test.dart
@@ -1,8 +1,9 @@
 // Copyright (c) 2018, the Zefyr project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+import 'dart:io';
+
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zefyr/src/widgets/buttons.dart';
 import 'package:zefyr/zefyr.dart';
@@ -145,21 +146,11 @@ void main() {
   });
 
   group('$ImageButton', () {
-    const MethodChannel channel =
-        const MethodChannel('plugins.flutter.io/image_picker');
-
-    final List<MethodCall> log = <MethodCall>[];
-
-    setUp(() {
-      channel.setMockMethodCallHandler((MethodCall methodCall) async {
-        log.add(methodCall);
-        return '/tmp/test.jpg';
-      });
-      log.clear();
-    });
-
     testWidgets('toggle overlay', (tester) async {
-      final editor = new EditorSandBox(tester: tester);
+      final editor = new EditorSandBox(
+        tester: tester,
+        imageDelegate: _TestImageDelegate(),
+      );
       await editor.pumpAndTap();
       await editor.tapButtonWithIcon(Icons.photo);
 
@@ -169,41 +160,43 @@ void main() {
     });
 
     testWidgets('pick from camera', (tester) async {
-      final editor = new EditorSandBox(tester: tester);
+      final editor = new EditorSandBox(
+        tester: tester,
+        imageDelegate: _TestImageDelegate(),
+      );
       await editor.pumpAndTap();
       await editor.tapButtonWithIcon(Icons.photo);
       await editor.tapButtonWithIcon(Icons.photo_camera);
-      expect(log, hasLength(1));
-      expect(
-        log.single,
-        isMethodCall(
-          'pickImage',
-          arguments: <String, dynamic>{
-            'source': 0,
-            'maxWidth': null,
-            'maxHeight': null,
-          },
-        ),
-      );
+      expect(find.byType(ZefyrImage), findsOneWidget);
     });
 
     testWidgets('pick from gallery', (tester) async {
-      final editor = new EditorSandBox(tester: tester);
+      final editor = new EditorSandBox(
+        tester: tester,
+        imageDelegate: _TestImageDelegate(),
+      );
       await editor.pumpAndTap();
       await editor.tapButtonWithIcon(Icons.photo);
       await editor.tapButtonWithIcon(Icons.photo_library);
-      expect(log, hasLength(1));
-      expect(
-        log.single,
-        isMethodCall(
-          'pickImage',
-          arguments: <String, dynamic>{
-            'source': 1,
-            'maxWidth': null,
-            'maxHeight': null,
-          },
-        ),
-      );
+      expect(find.byType(ZefyrImage), findsOneWidget);
     });
   });
+}
+
+class _TestImageDelegate implements ZefyrImageDelegate<String> {
+  @override
+  Widget buildImage(BuildContext context, String key) {
+    return Image.file(File(key));
+  }
+
+  @override
+  String get cameraSource => "camera";
+
+  @override
+  String get gallerySource => "gallery";
+
+  @override
+  Future<String> pickImage(String source) {
+    return Future.value("file:///tmp/test.jpg");
+  }
 }

--- a/packages/zefyr/test/widgets/image_test.dart
+++ b/packages/zefyr/test/widgets/image_test.dart
@@ -1,52 +1,21 @@
 // Copyright (c) 2018, the Zefyr project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+import 'dart:io';
+
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:image_picker/image_picker.dart';
 import 'package:zefyr/zefyr.dart';
 
 import '../testing.dart';
 
 void main() {
-  group('$ZefyrDefaultImageDelegate', () {
-    const MethodChannel channel =
-        const MethodChannel('plugins.flutter.io/image_picker');
-
-    final List<MethodCall> log = <MethodCall>[];
-
-    setUp(() {
-      channel.setMockMethodCallHandler((MethodCall methodCall) async {
-        log.add(methodCall);
-        return '/tmp/test.jpg';
-      });
-      log.clear();
-    });
-
-    test('pick image', () async {
-      final delegate = new ZefyrDefaultImageDelegate();
-      final result = await delegate.pickImage(ImageSource.gallery);
-      expect(result, 'file:///tmp/test.jpg');
-    });
-  });
-
   group('$ZefyrImage', () {
-    const MethodChannel channel =
-        const MethodChannel('plugins.flutter.io/image_picker');
-
-    final List<MethodCall> log = <MethodCall>[];
-
-    setUp(() {
-      channel.setMockMethodCallHandler((MethodCall methodCall) async {
-        log.add(methodCall);
-        return '/tmp/test.jpg';
-      });
-      log.clear();
-    });
-
     testWidgets('embed image', (tester) async {
-      final editor = new EditorSandBox(tester: tester);
+      final editor = new EditorSandBox(
+        tester: tester,
+        imageDelegate: _TestImageDelegate(),
+      );
       await editor.pumpAndTap();
       await editor.tapButtonWithIcon(Icons.photo);
       await editor.tapButtonWithIcon(Icons.photo_camera);
@@ -62,7 +31,10 @@ void main() {
 
     testWidgets('tap on left side of image puts caret before it',
         (tester) async {
-      final editor = new EditorSandBox(tester: tester);
+      final editor = new EditorSandBox(
+        tester: tester,
+        imageDelegate: _TestImageDelegate(),
+      );
       await editor.pumpAndTap();
       await editor.tapButtonWithIcon(Icons.photo);
       await editor.tapButtonWithIcon(Icons.photo_camera);
@@ -76,7 +48,10 @@ void main() {
     });
 
     testWidgets('tap right side of image puts caret after it', (tester) async {
-      final editor = new EditorSandBox(tester: tester);
+      final editor = new EditorSandBox(
+        tester: tester,
+        imageDelegate: _TestImageDelegate(),
+      );
       await editor.pumpAndTap();
       await editor.tapButtonWithIcon(Icons.photo);
       await editor.tapButtonWithIcon(Icons.photo_camera);
@@ -92,7 +67,10 @@ void main() {
     });
 
     testWidgets('selects on long press', (tester) async {
-      final editor = new EditorSandBox(tester: tester);
+      final editor = new EditorSandBox(
+        tester: tester,
+        imageDelegate: _TestImageDelegate(),
+      );
       await editor.pumpAndTap();
       await editor.tapButtonWithIcon(Icons.photo);
       await editor.tapButtonWithIcon(Icons.photo_camera);
@@ -107,4 +85,22 @@ void main() {
       expect(find.text('PASTE'), findsOneWidget);
     });
   });
+}
+
+class _TestImageDelegate implements ZefyrImageDelegate<String> {
+  @override
+  Widget buildImage(BuildContext context, String key) {
+    return Image.file(File(key));
+  }
+
+  @override
+  String get cameraSource => "camera";
+
+  @override
+  String get gallerySource => "gallery";
+
+  @override
+  Future<String> pickImage(String source) {
+    return Future.value("file:///tmp/test.jpg");
+  }
 }

--- a/packages/zefyr/test/widgets/scope_test.dart
+++ b/packages/zefyr/test/widgets/scope_test.dart
@@ -16,7 +16,6 @@ void main() {
       scope = ZefyrScope.editable(
         mode: ZefyrMode.edit,
         controller: ZefyrController(doc),
-        imageDelegate: ZefyrDefaultImageDelegate(),
         focusNode: FocusNode(),
         focusScope: FocusScopeNode(),
       );
@@ -27,7 +26,7 @@ void main() {
       scope.addListener(() {
         notified = true;
       });
-      final delegate = ZefyrDefaultImageDelegate();
+      final delegate = _TestImageDelegate();
       scope.imageDelegate = delegate;
       expect(notified, isTrue);
       notified = false;
@@ -73,4 +72,22 @@ void main() {
       expect(notified, isTrue);
     });
   });
+}
+
+class _TestImageDelegate implements ZefyrImageDelegate<String> {
+  @override
+  Widget buildImage(BuildContext context, String key) {
+    return null;
+  }
+
+  @override
+  String get cameraSource => null;
+
+  @override
+  String get gallerySource => null;
+
+  @override
+  Future<String> pickImage(String source) {
+    return null;
+  }
 }


### PR DESCRIPTION
* Allows to reduce friction when users want to upgrade their dependencies.
* We only depended on `image_picker` to have default basic implementation of image delegate interface, however was just an example which is unlikely to be used in real-world applications.
* Gets Zefyr one step closer to allow customizing available actions and define 3rd party actions as well.

Addresses #137 , #94 and #82 (partially).