### PR TITLE
Fixes `The getter 'documentOffset' was called on null.`

### DIFF
--- a/packages/notus/lib/src/document/node.dart
+++ b/packages/notus/lib/src/document/node.dart
@@ -53,7 +53,7 @@ abstract class Node extends LinkedListEntry<Node> {
 
   /// Offset in characters of this node in the document.
   int get documentOffset {
-    int parentOffset = (_parent is! RootNode) ? _parent.documentOffset : 0;
+    int parentOffset = (_parent is! RootNode && _parent != null) ? _parent.documentOffset : 0;
     return parentOffset + this.offset;
   }
 


### PR DESCRIPTION
This is meant to prevent `The getter 'documentOffset' was called on null.` in some cases