### PR TITLE
Markdown decoder

### DIFF
--- a/packages/notus/lib/src/convert/markdown.dart
+++ b/packages/notus/lib/src/convert/markdown.dart
@@ -20,9 +20,9 @@ class NotusMarkdownCodec extends Codec<Delta, String> {
 class _NotusMarkdownDecoder extends Converter<String, Delta> {
   final List<Map<String, dynamic>> _attributesByStyleLength = [
     null,
-    {'i': true},            // _
-    {'b': true },           // **
-    {'i': true, 'b': true } // **_
+    {'i': true}, // _
+    {'b': true}, // **
+    {'i': true, 'b': true} // **_
   ];
   final RegExp _headingRegExp = RegExp(r'(#+) *(.+)');
   final RegExp _styleRegExp = RegExp(r'((?:\*|_){1,3})(.*?[^\1 ])\1');
@@ -46,7 +46,7 @@ class _NotusMarkdownDecoder extends Converter<String, Delta> {
 
     return delta;
   }
-  
+
   _handleLine(String line, Delta delta, [Map<String, dynamic> attributes]) {
     if (_handleBlockQuote(line, delta, attributes)) {
       return;
@@ -65,7 +65,8 @@ class _NotusMarkdownDecoder extends Converter<String, Delta> {
 
   /// Markdown supports headings and blocks within blocks (except for within code)
   /// but not blocks within headers, or ul within
-  bool _handleBlock(String line, Delta delta, [Map<String, dynamic> attributes]) {
+  bool _handleBlock(String line, Delta delta,
+      [Map<String, dynamic> attributes]) {
     var match;
 
     match = _codeRegExp.matchAsPrefix(line);
@@ -74,12 +75,16 @@ class _NotusMarkdownDecoder extends Converter<String, Delta> {
       return true;
     }
     if (_inBlockStack) {
-      delta.insert(line + '\n', NotusAttribute.code.toJson()); // TODO: replace with?: {'quote': true})
+      delta.insert(
+          line + '\n',
+          NotusAttribute.code
+              .toJson()); // TODO: replace with?: {'quote': true})
       // Don't bother testing for code blocks within block stacks
       return true;
     }
 
-    if (_handleOrderedList(line, delta, attributes) || _handleUnorderedList(line, delta, attributes)) {
+    if (_handleOrderedList(line, delta, attributes) ||
+        _handleUnorderedList(line, delta, attributes)) {
       return true;
     }
 
@@ -87,11 +92,14 @@ class _NotusMarkdownDecoder extends Converter<String, Delta> {
   }
 
   /// all blocks are supported within bq
-  bool _handleBlockQuote(String line, Delta delta, [Map<String, dynamic> attributes]) {
+  bool _handleBlockQuote(String line, Delta delta,
+      [Map<String, dynamic> attributes]) {
     var match = _bqRegExp.matchAsPrefix(line);
     if (match != null) {
       var span = match.group(1);
-      Map<String, dynamic> newAttributes = {'block': 'quote'}; // NotusAttribute.bq.toJson();
+      Map<String, dynamic> newAttributes = {
+        'block': 'quote'
+      }; // NotusAttribute.bq.toJson();
       if (attributes != null) {
         newAttributes.addAll(attributes);
       }
@@ -103,7 +111,8 @@ class _NotusMarkdownDecoder extends Converter<String, Delta> {
   }
 
   /// ol is supported within ol and bq, but not supported within ul
-  bool _handleOrderedList(String line, Delta delta, [Map<String, dynamic> attributes]) {
+  bool _handleOrderedList(String line, Delta delta,
+      [Map<String, dynamic> attributes]) {
     var match = _olRegExp.matchAsPrefix(line);
     if (match != null) {
 // TODO: support nesting
@@ -120,10 +129,11 @@ class _NotusMarkdownDecoder extends Converter<String, Delta> {
     return false;
   }
 
-  bool _handleUnorderedList(String line, Delta delta, [Map<String, dynamic> attributes]) {
+  bool _handleUnorderedList(String line, Delta delta,
+      [Map<String, dynamic> attributes]) {
     var match = _ulRegExp.matchAsPrefix(line);
     if (match != null) {
-      var depth =  match.group(1).length / 3;
+      var depth = match.group(1).length / 3;
       var span = match.group(2);
       Map<String, dynamic> newAttributes = NotusAttribute.ul.toJson();
       if (attributes != null) {
@@ -135,12 +145,14 @@ class _NotusMarkdownDecoder extends Converter<String, Delta> {
     }
     return false;
   }
-  
+
   _handleHeading(String line, Delta delta, [Map<String, dynamic> attributes]) {
     var match = _headingRegExp.matchAsPrefix(line);
     if (match != null) {
       var level = match.group(1).length;
-      Map<String, dynamic> newAttributes = {'heading': level}; // NotusAttribute.heading.withValue(level).toJson();
+      Map<String, dynamic> newAttributes = {
+        'heading': level
+      }; // NotusAttribute.heading.withValue(level).toJson();
       if (attributes != null) {
         newAttributes.addAll(attributes);
       }
@@ -151,11 +163,12 @@ class _NotusMarkdownDecoder extends Converter<String, Delta> {
 //      delta.insert('\n', attribute.toJson());
       return true;
     }
-    
+
     return false;
   }
 
-  _handleSpan(String span, Delta delta, bool addNewLine, Map<String, dynamic> outerStyle) {
+  _handleSpan(String span, Delta delta, bool addNewLine,
+      Map<String, dynamic> outerStyle) {
     var start = _handleStyles(span, delta, outerStyle);
     span = span.substring(start);
 
@@ -183,7 +196,9 @@ class _NotusMarkdownDecoder extends Converter<String, Delta> {
       if (match.start > start) {
         if (span.substring(match.start - 1, match.start) == '[') {
           delta.insert(span.substring(start, match.start - 1), outerStyle);
-          start = match.start - 1 + _handleLinks(span.substring(match.start - 1), delta, outerStyle);
+          start = match.start -
+              1 +
+              _handleLinks(span.substring(match.start - 1), delta, outerStyle);
           return;
         } else {
           delta.insert(span.substring(start, match.start), outerStyle);
@@ -191,7 +206,8 @@ class _NotusMarkdownDecoder extends Converter<String, Delta> {
       }
 
       var text = match.group(2);
-      var newStyle = Map<String, dynamic>.from(_attributesByStyleLength[match.group(1).length]);
+      var newStyle = Map<String, dynamic>.from(
+          _attributesByStyleLength[match.group(1).length]);
       if (outerStyle != null) {
         newStyle.addAll(outerStyle);
       }
@@ -213,7 +229,9 @@ class _NotusMarkdownDecoder extends Converter<String, Delta> {
 
       var text = match.group(1);
       var href = match.group(2);
-      Map<String, dynamic> newAttributes = {'a': href}; // NotusAttribute.link.fromString(href).toJson();
+      Map<String, dynamic> newAttributes = {
+        'a': href
+      }; // NotusAttribute.link.fromString(href).toJson();
       if (outerStyle != null) {
         newAttributes.addAll(outerStyle);
       }

--- a/packages/notus/lib/src/convert/markdown.dart
+++ b/packages/notus/lib/src/convert/markdown.dart
@@ -133,7 +133,7 @@ class _NotusMarkdownDecoder extends Converter<String, Delta> {
       [Map<String, dynamic> attributes]) {
     var match = _ulRegExp.matchAsPrefix(line);
     if (match != null) {
-      var depth = match.group(1).length / 3;
+//      var depth = match.group(1).length / 3;
       var span = match.group(2);
       Map<String, dynamic> newAttributes = NotusAttribute.ul.toJson();
       if (attributes != null) {

--- a/packages/notus/lib/src/convert/markdown.dart
+++ b/packages/notus/lib/src/convert/markdown.dart
@@ -22,7 +22,7 @@ class _NotusMarkdownDecoder extends Converter<String, Delta> {
   final RegExp _headingRegExp = RegExp(r'(#+) (.+)');
   final RegExp _styleRegExp = RegExp(r'((?:\*|_){1,3})(.*?[^\1 ])\1');
   final RegExp _linkRegExp = RegExp(r'\[([^\]]+)\]\(([^\)]+)\)');
-  final attributesByStyleLength = [null, {'i': true}, {'b': true }, {'i': true, 'b': true }];
+  final List<Map<String, dynamic>> attributesByStyleLength = [null, {'i': true}, {'b': true }, {'i': true, 'b': true }];
 
   @override
   Delta convert(String input) {
@@ -77,11 +77,17 @@ class _NotusMarkdownDecoder extends Converter<String, Delta> {
     var matches = _styleRegExp.allMatches(span);
     matches.forEach((match) {
       if (match.start > start) {
-        delta.insert(span.substring(start, match.start), outerStyle);
+        if (span.substring(match.start - 1, match.start) == '[') {
+          delta.insert(span.substring(start, match.start - 1), outerStyle);
+          start = match.start - 1 + _handleLinks(span.substring(match.start - 1), delta, outerStyle);
+          return;
+        } else {
+          delta.insert(span.substring(start, match.start), outerStyle);
+        }
       }
 
       var text = match.group(2);
-      var newStyle = attributesByStyleLength[match.group(1).length];
+      Map<String, dynamic> newStyle = attributesByStyleLength[match.group(1).length];
       if (outerStyle != null) {
         newStyle.addAll(outerStyle);
       }

--- a/packages/notus/test/convert/markdown_test.dart
+++ b/packages/notus/test/convert/markdown_test.dart
@@ -55,8 +55,12 @@ void main() {
         }
       }
 
-      runFor('Okay, _this is in italics_ and _so is all of _ this_ but this is not\n\n', true);
-      runFor('Okay, *this is in italics* and *so is all of _ this* but this is not\n\n', false);
+      runFor(
+          'Okay, _this is in italics_ and _so is all of _ this_ but this is not\n\n',
+          true);
+      runFor(
+          'Okay, *this is in italics* and *so is all of _ this* but this is not\n\n',
+          false);
     });
 
     test('bold', () {
@@ -80,14 +84,14 @@ void main() {
         final delta = notusMarkdown.decode(markdown);
         expect(delta.elementAt(0).data, 'Okay, ');
         expect(delta.elementAt(0).attributes, null);
-  
+
         expect(delta.elementAt(1).data, 'this is bold');
         expect(delta.elementAt(1).attributes["b"], true);
         expect(delta.elementAt(1).attributes["i"], null);
-        
+
         expect(delta.elementAt(3).data, 'so is all of __ this');
         expect(delta.elementAt(3).attributes["b"], true);
-  
+
         expect(delta.elementAt(4).data, ' but this is not\n');
         expect(delta.elementAt(4).attributes, null);
         if (testEncode) {
@@ -95,9 +99,13 @@ void main() {
           expect(andBack, markdown);
         }
       }
-      
-      runFor('Okay, **this is bold** and **so is all of __ this** but this is not\n\n', true);
-      runFor('Okay, __this is bold__ and __so is all of __ this__ but this is not\n\n', false);
+
+      runFor(
+          'Okay, **this is bold** and **so is all of __ this** but this is not\n\n',
+          true);
+      runFor(
+          'Okay, __this is bold__ and __so is all of __ this__ but this is not\n\n',
+          false);
     });
 
     test('intersecting inline styles', () {
@@ -162,9 +170,12 @@ void main() {
         }
       }
 
-      runFor('**this is bold** _this is in italics_ and **_this is both_**\n\n', true);
-      runFor('**this is bold** *this is in italics* and ***this is both***\n\n', false);
-      runFor('__this is bold__ _this is in italics_ and ___this is both___\n\n', false);
+      runFor('**this is bold** _this is in italics_ and **_this is both_**\n\n',
+          true);
+      runFor('**this is bold** *this is in italics* and ***this is both***\n\n',
+          false);
+      runFor('__this is bold__ _this is in italics_ and ___this is both___\n\n',
+          false);
     });
 
     test('link', () {
@@ -253,7 +264,8 @@ void main() {
 
     test('simple bq', () {
 //      var markdown = '> quote\n> > nested\n>#Heading\n>**bold**\n>_italics_\n>* bullet\n>1. 1st point\n>1. 2nd point\n\n';
-      var markdown = '> quote\n> # Heading in Quote\n> # **Styled** heading in _block quote_\n> **bold text**\n> _text in italics_\n\n';
+      var markdown =
+          '> quote\n> # Heading in Quote\n> # **Styled** heading in _block quote_\n> **bold text**\n> _text in italics_\n\n';
       final delta = notusMarkdown.decode(markdown);
 
       expect(delta.elementAt(0).data, 'quote\n');

--- a/packages/notus/test/convert/markdown_test.dart
+++ b/packages/notus/test/convert/markdown_test.dart
@@ -207,9 +207,15 @@ void main() {
       expect(delta.elementAt(1).attributes["b"], true);
       expect(delta.elementAt(1).attributes["a"], null);
 
+      expect(delta.elementAt(2).data, ' is a ');
+      expect(delta.elementAt(2).attributes, null);
+
       expect(delta.elementAt(3).data, 'circus');
       expect(delta.elementAt(3).attributes["b"], true);
       expect(delta.elementAt(3).attributes["a"], 'https://github.com');
+
+      expect(delta.elementAt(4).data, '\n');
+      expect(delta.length, 5);
 
       final andBack = notusMarkdown.encode(delta);
       expect(andBack, markdown);

--- a/packages/notus/test/convert/markdown_test.dart
+++ b/packages/notus/test/convert/markdown_test.dart
@@ -221,36 +221,11 @@ void main() {
       expect(andBack, markdown);
     });
 
-    test('foo', () {
-      runFor(NotusAttribute<bool> attribute, String markdown) {
-        final delta = notusMarkdown.decode(markdown);
-//        expect(delta.elementAt(0).data, 'First line\nSecond line\n');
-        final andBack = notusMarkdown.encode(delta);
-        expect(andBack, markdown);
-
-//          ..insert('This ')
-//          ..insert('house', attribute.toJson())
-//          ..insert(' is a ')
-//          ..insert('circus', attribute.toJson())
-//          ..insert('\n');
-      }
-
-//      runFor(NotusAttribute.bold, 'This **house** is a __circus__\n\n');
-//      runFor(NotusAttribute.italic, 'This _house_ is a *circus*\n\n');
-//      runFor(NotusAttribute.bold, '*italic*\n\n');
-      runFor(NotusAttribute.bold, '_italic_\n\n');
-      runFor(NotusAttribute.bold, '**bold**\n\n');
-//      runFor(NotusAttribute.bold, '__bold__\n\n');
-      runFor(NotusAttribute.bold, '**_bold and italic_**\n\n');
-//      runFor(NotusAttribute.bold, '***italic and bold***\n\n');
-      runFor(NotusAttribute.bold, 'Here is some *italic * star* and _italic _ lodash_ and **bold * star** and __bold _ lodash__\n\n');
-    });
-
     test('heading styles', () {
       runFor(String markdown, int level) {
         final delta = notusMarkdown.decode(markdown);
-        expect(delta.elementAt(0).data, 'This is an H$level');
-        expect(delta.elementAt(1).attributes['heading'], level);
+        expect(delta.elementAt(0).data, 'This is an H$level\n');
+        expect(delta.elementAt(0).attributes['heading'], level);
         final andBack = notusMarkdown.encode(delta);
         expect(andBack, markdown);
       }
@@ -258,6 +233,90 @@ void main() {
       runFor('# This is an H1\n\n', 1);
       runFor('## This is an H2\n\n', 2);
       runFor('### This is an H3\n\n', 3);
+    });
+
+    test('ul', () {
+      var markdown = '* a bullet point\n* another bullet point\n\n';
+      final delta = notusMarkdown.decode(markdown);
+
+      final andBack = notusMarkdown.encode(delta);
+      expect(andBack, markdown);
+    });
+
+    test('ol', () {
+      var markdown = '1. 1st point\n1. 2nd point\n\n';
+      final delta = notusMarkdown.decode(markdown);
+
+      final andBack = notusMarkdown.encode(delta);
+      expect(andBack, markdown);
+    });
+
+    test('simple bq', () {
+//      var markdown = '> quote\n> > nested\n>#Heading\n>**bold**\n>_italics_\n>* bullet\n>1. 1st point\n>1. 2nd point\n\n';
+      var markdown = '> quote\n> # Heading in Quote\n> # **Styled** heading in _block quote_\n> **bold text**\n> _text in italics_\n\n';
+      final delta = notusMarkdown.decode(markdown);
+
+      expect(delta.elementAt(0).data, 'quote\n');
+      expect(delta.elementAt(0).attributes['block'], 'quote');
+      expect(delta.elementAt(0).attributes.length, 1);
+
+      expect(delta.elementAt(1).data, 'Heading in Quote\n');
+      expect(delta.elementAt(1).attributes['block'], 'quote');
+      expect(delta.elementAt(1).attributes['heading'], 1);
+      expect(delta.elementAt(1).attributes.length, 2);
+
+      expect(delta.elementAt(2).data, 'Styled');
+      expect(delta.elementAt(2).attributes['block'], 'quote');
+      expect(delta.elementAt(2).attributes['heading'], 1);
+      expect(delta.elementAt(2).attributes['b'], true);
+      expect(delta.elementAt(2).attributes.length, 3);
+
+      expect(delta.elementAt(3).data, ' heading in ');
+      expect(delta.elementAt(3).attributes['block'], 'quote');
+      expect(delta.elementAt(3).attributes['heading'], 1);
+      expect(delta.elementAt(3).attributes.length, 2);
+
+      expect(delta.elementAt(4).data, 'block quote');
+      expect(delta.elementAt(4).attributes['block'], 'quote');
+      expect(delta.elementAt(4).attributes['heading'], 1);
+      expect(delta.elementAt(4).attributes['i'], true);
+      expect(delta.elementAt(4).attributes.length, 3);
+
+      expect(delta.elementAt(6).data, 'bold text');
+      expect(delta.elementAt(6).attributes['block'], 'quote');
+      expect(delta.elementAt(6).attributes['b'], true);
+      expect(delta.elementAt(6).attributes.length, 2);
+
+      expect(delta.elementAt(8).data, 'text in italics');
+      expect(delta.elementAt(8).attributes['block'], 'quote');
+      expect(delta.elementAt(8).attributes['i'], true);
+      expect(delta.elementAt(8).attributes.length, 2);
+
+      final andBack = notusMarkdown.encode(delta);
+      expect(andBack, markdown);
+    });
+
+    /*test('nested bq', () {
+      var markdown = '> > nested\n>* bullet\n>1. 1st point\n>1. 2nd point\n\n';
+      final delta = notusMarkdown.decode(markdown);
+
+      final andBack = notusMarkdown.encode(delta);
+      expect(andBack, markdown);
+    });
+
+    test('code in bq', () {
+      var markdown = '> ```\n> print("Hello world!")\n> ```\n\n';
+      final delta = notusMarkdown.decode(markdown);
+
+      final andBack = notusMarkdown.encode(delta);
+      expect(andBack, markdown);
+    });*/
+
+    test('multiple styles', () {
+      final delta = notusMarkdown.decode(expectedMarkdown);
+//      expect(delta, doc);
+      final andBack = notusMarkdown.encode(delta);
+      expect(andBack, expectedMarkdown);
     });
   });
 

--- a/packages/notus/test/convert/markdown_test.dart
+++ b/packages/notus/test/convert/markdown_test.dart
@@ -10,10 +10,248 @@ import 'package:notus/convert.dart';
 
 void main() {
   group('$NotusMarkdownCodec.encode', () {
-    test('unimplemented', () {
-      expect(() {
-        notusMarkdown.decode('test');
-      }, throwsUnimplementedError);
+    test('paragraphs', () {
+      final markdown = 'First line\n\nSecond line\n\n';
+      final delta = notusMarkdown.decode(markdown);
+      expect(delta.elementAt(0).data, 'First line\nSecond line\n');
+      final andBack = notusMarkdown.encode(delta);
+      expect(andBack, markdown);
+    });
+
+    test('italics', () {
+      runFor(String markdown, bool testEncode) {
+        final delta = notusMarkdown.decode(markdown);
+        expect(delta.elementAt(0).data, 'italics');
+        expect(delta.elementAt(0).attributes["i"], true);
+        expect(delta.elementAt(0).attributes["b"], null);
+        if (testEncode) {
+          final andBack = notusMarkdown.encode(delta);
+          expect(andBack, markdown);
+        }
+      }
+
+      runFor('_italics_\n\n', true);
+      runFor('*italics*\n\n', false);
+    });
+
+    test('multi-word italics', () {
+      runFor(String markdown, bool testEncode) {
+        final delta = notusMarkdown.decode(markdown);
+        expect(delta.elementAt(0).data, 'Okay, ');
+        expect(delta.elementAt(0).attributes, null);
+
+        expect(delta.elementAt(1).data, 'this is in italics');
+        expect(delta.elementAt(1).attributes["i"], true);
+        expect(delta.elementAt(1).attributes["b"], null);
+
+        expect(delta.elementAt(3).data, 'so is all of _ this');
+        expect(delta.elementAt(3).attributes["i"], true);
+
+        expect(delta.elementAt(4).data, ' but this is not\n');
+        expect(delta.elementAt(4).attributes, null);
+        if (testEncode) {
+          final andBack = notusMarkdown.encode(delta);
+          expect(andBack, markdown);
+        }
+      }
+
+      runFor('Okay, _this is in italics_ and _so is all of _ this_ but this is not\n\n', true);
+      runFor('Okay, *this is in italics* and *so is all of _ this* but this is not\n\n', false);
+    });
+
+    test('bold', () {
+      runFor(String markdown, bool testEncode) {
+        final delta = notusMarkdown.decode(markdown);
+        expect(delta.elementAt(0).data, 'bold');
+        expect(delta.elementAt(0).attributes["b"], true);
+        expect(delta.elementAt(0).attributes["i"], null);
+        if (testEncode) {
+          final andBack = notusMarkdown.encode(delta);
+          expect(andBack, markdown);
+        }
+      }
+
+      runFor('**bold**\n\n', true);
+      runFor('__bold__\n\n', false);
+    });
+
+    test('multi-word bold', () {
+      runFor(String markdown, bool testEncode) {
+        final delta = notusMarkdown.decode(markdown);
+        expect(delta.elementAt(0).data, 'Okay, ');
+        expect(delta.elementAt(0).attributes, null);
+  
+        expect(delta.elementAt(1).data, 'this is bold');
+        expect(delta.elementAt(1).attributes["b"], true);
+        expect(delta.elementAt(1).attributes["i"], null);
+        
+        expect(delta.elementAt(3).data, 'so is all of __ this');
+        expect(delta.elementAt(3).attributes["b"], true);
+  
+        expect(delta.elementAt(4).data, ' but this is not\n');
+        expect(delta.elementAt(4).attributes, null);
+        if (testEncode) {
+          final andBack = notusMarkdown.encode(delta);
+          expect(andBack, markdown);
+        }
+      }
+      
+      runFor('Okay, **this is bold** and **so is all of __ this** but this is not\n\n', true);
+      runFor('Okay, __this is bold__ and __so is all of __ this__ but this is not\n\n', false);
+    });
+
+    test('intersecting inline styles', () {
+      var markdown = 'This **house _is a_ circus**\n\n';
+      final delta = notusMarkdown.decode(markdown);
+      expect(delta.elementAt(1).data, 'house ');
+      expect(delta.elementAt(1).attributes["b"], true);
+      expect(delta.elementAt(1).attributes["i"], null);
+
+      expect(delta.elementAt(2).data, 'is a');
+      expect(delta.elementAt(2).attributes["b"], true);
+      expect(delta.elementAt(2).attributes["i"], true);
+
+      expect(delta.elementAt(3).data, ' circus');
+      expect(delta.elementAt(3).attributes["b"], true);
+      expect(delta.elementAt(3).attributes["i"], null);
+
+      final andBack = notusMarkdown.encode(delta);
+      expect(andBack, markdown);
+    });
+
+    test('bold and italics', () {
+      runFor(String markdown, bool testEncode) {
+        final delta = notusMarkdown.decode(markdown);
+        expect(delta.elementAt(0).data, 'this is bold and italic');
+        expect(delta.elementAt(0).attributes["b"], true);
+        expect(delta.elementAt(0).attributes["i"], true);
+
+        expect(delta.elementAt(1).data, '\n');
+        expect(delta.length, 2);
+
+        if (testEncode) {
+          final andBack = notusMarkdown.encode(delta);
+          expect(andBack, markdown);
+        }
+      }
+
+      runFor('**_this is bold and italic_**\n\n', true);
+      runFor('_**this is bold and italic**_\n\n', true);
+      runFor('***this is bold and italic***\n\n', false);
+      runFor('___this is bold and italic___\n\n', false);
+    });
+
+    test('bold and italics combinations', () {
+      runFor(String markdown, bool testEncode) {
+        final delta = notusMarkdown.decode(markdown);
+        expect(delta.elementAt(0).data, 'this is bold');
+        expect(delta.elementAt(0).attributes["b"], true);
+        expect(delta.elementAt(0).attributes["i"], null);
+
+        expect(delta.elementAt(2).data, 'this is in italics');
+        expect(delta.elementAt(2).attributes["b"], null);
+        expect(delta.elementAt(2).attributes["i"], true);
+
+        expect(delta.elementAt(4).data, 'this is both');
+        expect(delta.elementAt(4).attributes["b"], true);
+        expect(delta.elementAt(4).attributes["i"], true);
+
+        if (testEncode) {
+          final andBack = notusMarkdown.encode(delta);
+          expect(andBack, markdown);
+        }
+      }
+
+      runFor('**this is bold** _this is in italics_ and **_this is both_**\n\n', true);
+      runFor('**this is bold** *this is in italics* and ***this is both***\n\n', false);
+      runFor('__this is bold__ _this is in italics_ and ___this is both___\n\n', false);
+    });
+
+    test('link', () {
+      var markdown = 'This **house** is a [circus](https://github.com)\n\n';
+      final delta = notusMarkdown.decode(markdown);
+
+      expect(delta.elementAt(1).data, 'house');
+      expect(delta.elementAt(1).attributes["b"], true);
+      expect(delta.elementAt(1).attributes["a"], null);
+
+      expect(delta.elementAt(3).data, 'circus');
+      expect(delta.elementAt(3).attributes["b"], null);
+      expect(delta.elementAt(3).attributes["a"], 'https://github.com');
+
+      final andBack = notusMarkdown.encode(delta);
+      expect(andBack, markdown);
+    });
+
+    test('style around link', () {
+      var markdown = 'This **house** is a **[circus](https://github.com)**\n\n';
+      final delta = notusMarkdown.decode(markdown);
+
+      expect(delta.elementAt(1).data, 'house');
+      expect(delta.elementAt(1).attributes["b"], true);
+      expect(delta.elementAt(1).attributes["a"], null);
+
+      expect(delta.elementAt(3).data, 'circus');
+      expect(delta.elementAt(3).attributes["b"], true);
+      expect(delta.elementAt(3).attributes["a"], 'https://github.com');
+
+      final andBack = notusMarkdown.encode(delta);
+      expect(andBack, markdown);
+    });
+
+    test('style within link', () {
+      var markdown = 'This **house** is a [**circus**](https://github.com)\n\n';
+      final delta = notusMarkdown.decode(markdown);
+
+      expect(delta.elementAt(1).data, 'house');
+      expect(delta.elementAt(1).attributes["b"], true);
+      expect(delta.elementAt(1).attributes["a"], null);
+
+      expect(delta.elementAt(3).data, 'circus');
+      expect(delta.elementAt(3).attributes["b"], true);
+      expect(delta.elementAt(3).attributes["a"], 'https://github.com');
+
+      final andBack = notusMarkdown.encode(delta);
+      expect(andBack, markdown);
+    });
+
+    test('foo', () {
+      runFor(NotusAttribute<bool> attribute, String markdown) {
+        final delta = notusMarkdown.decode(markdown);
+//        expect(delta.elementAt(0).data, 'First line\nSecond line\n');
+        final andBack = notusMarkdown.encode(delta);
+        expect(andBack, markdown);
+
+//          ..insert('This ')
+//          ..insert('house', attribute.toJson())
+//          ..insert(' is a ')
+//          ..insert('circus', attribute.toJson())
+//          ..insert('\n');
+      }
+
+//      runFor(NotusAttribute.bold, 'This **house** is a __circus__\n\n');
+//      runFor(NotusAttribute.italic, 'This _house_ is a *circus*\n\n');
+//      runFor(NotusAttribute.bold, '*italic*\n\n');
+      runFor(NotusAttribute.bold, '_italic_\n\n');
+      runFor(NotusAttribute.bold, '**bold**\n\n');
+//      runFor(NotusAttribute.bold, '__bold__\n\n');
+      runFor(NotusAttribute.bold, '**_bold and italic_**\n\n');
+//      runFor(NotusAttribute.bold, '***italic and bold***\n\n');
+      runFor(NotusAttribute.bold, 'Here is some *italic * star* and _italic _ lodash_ and **bold * star** and __bold _ lodash__\n\n');
+    });
+
+    test('heading styles', () {
+      runFor(String markdown, int level) {
+        final delta = notusMarkdown.decode(markdown);
+        expect(delta.elementAt(0).data, 'This is an H$level');
+        expect(delta.elementAt(1).attributes['heading'], level);
+        final andBack = notusMarkdown.encode(delta);
+        expect(andBack, markdown);
+      }
+
+      runFor('# This is an H1\n\n', 1);
+      runFor('## This is an H2\n\n', 2);
+      runFor('### This is an H3\n\n', 3);
     });
   });
 


### PR DESCRIPTION
I have implemented the `_NotusMarkdownDecoder` but can not figure out how to nest blocks within block quotes - it is possible in Markdown, but does Notus have that capability? If so, how?