### PR TITLE
Fixed new Dart SDK Requirements

### DIFF
--- a/packages/zefyr/lib/src/widgets/input.dart
+++ b/packages/zefyr/lib/src/widgets/input.dart
@@ -15,6 +15,9 @@ class InputConnectionController implements TextInputClient {
   //
   // public members
   //
+    
+  @override
+  TextEditingValue get currentTextEditingValue => _lastKnownRemoteTextEditingValue;
 
   final RemoteValueChanged onValueChanged;
 


### PR DESCRIPTION
The new Dart TextInputClient requires the Getter: currentTextEditingValue.

Here you go.
Please review it asap, because we can't build nowhere till now