### PR TITLE
fix EditableBox paint cursor

### DIFF
--- a/packages/zefyr/lib/src/widgets/editable_box.dart
+++ b/packages/zefyr/lib/src/widgets/editable_box.dart
@@ -231,6 +231,7 @@ class RenderEditableProxyBox extends RenderBox
   }
 
   void _paintCursor(PaintingContext context, Offset offset) {
+    final _ = getOffsetForCaret(_selection.extent, Rect.zero);
     final caretOffset =
         getOffsetForCaret(_selection.extent, _cursorPainter.prototype);
     _cursorPainter.paint(context.canvas, caretOffset + offset);


### PR DESCRIPTION
The cursor does'n repaint when the `getOffsetForCaret` has same parameter.
