### PR TITLE
editor/field: support being expandable

### DIFF
--- a/packages/zefyr/lib/src/widgets/editable_text.dart
+++ b/packages/zefyr/lib/src/widgets/editable_text.dart
@@ -35,6 +35,7 @@ class ZefyrEditableText extends StatefulWidget {
     @required this.controller,
     @required this.focusNode,
     @required this.imageDelegate,
+    this.expands = false,
     this.selectionControls,
     this.autofocus = true,
     this.mode = ZefyrMode.edit,
@@ -76,6 +77,8 @@ class ZefyrEditableText extends StatefulWidget {
 
   /// Padding around editable area.
   final EdgeInsets padding;
+
+  final bool expands;
 
   /// The appearance of the keyboard.
   ///
@@ -150,6 +153,21 @@ class _ZefyrEditableTextState extends State<ZefyrEditableText>
     Widget body = ListBody(children: _buildChildren(context));
     if (widget.padding != null) {
       body = Padding(padding: widget.padding, child: body);
+    }
+
+    if (widget.expands) {
+      return Stack(fit: StackFit.passthrough, children: <Widget>[
+        body,
+        Positioned.fill(
+            left: 0,
+            right: 0,
+            bottom: 0,
+            top: 0,
+            child: ZefyrSelectionOverlay(
+              controls:
+                  widget.selectionControls ?? defaultSelectionControls(context),
+            ))
+      ]);
     }
 
     body = SingleChildScrollView(

--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -20,6 +20,7 @@ class ZefyrEditor extends StatefulWidget {
     Key key,
     @required this.controller,
     @required this.focusNode,
+    this.expands = false,
     this.autofocus = true,
     this.mode = ZefyrMode.edit,
     this.padding = const EdgeInsets.symmetric(horizontal: 16.0),
@@ -69,6 +70,11 @@ class ZefyrEditor extends StatefulWidget {
 
   /// Padding around editable area.
   final EdgeInsets padding;
+
+  /// Is the content wrapped in a scrollview or not?
+  ///
+  /// if true the content is not wrapped in a scrollview
+  final bool expands;
 
   /// The appearance of the keyboard.
   ///
@@ -196,6 +202,7 @@ class _ZefyrEditorState extends State<ZefyrEditor> {
       imageDelegate: _scope.imageDelegate,
       selectionControls: widget.selectionControls,
       autofocus: widget.autofocus,
+      expands: widget.expands,
       mode: widget.mode,
       padding: widget.padding,
       physics: widget.physics,

--- a/packages/zefyr/lib/src/widgets/field.dart
+++ b/packages/zefyr/lib/src/widgets/field.dart
@@ -20,6 +20,7 @@ class ZefyrField extends StatefulWidget {
   final ZefyrToolbarDelegate toolbarDelegate;
   final ZefyrImageDelegate imageDelegate;
   final ScrollPhysics physics;
+  final bool expands;
 
   /// The appearance of the keyboard.
   ///
@@ -40,6 +41,7 @@ class ZefyrField extends StatefulWidget {
     this.imageDelegate,
     this.physics,
     this.keyboardAppearance,
+    this.expands = false,
   }) : super(key: key);
 
   @override
@@ -55,6 +57,7 @@ class _ZefyrFieldState extends State<ZefyrField> {
       controller: widget.controller,
       focusNode: widget.focusNode,
       autofocus: widget.autofocus,
+      expands: widget.expands,
       mode: _effectiveMode,
       toolbarDelegate: widget.toolbarDelegate,
       imageDelegate: widget.imageDelegate,


### PR DESCRIPTION
Ensure Zefyr can be expandable (to put it in column, ..)