### PR TITLE
Fix Compiling with Flutter 1.22

### DIFF
--- a/packages/zefyr/lib/src/widgets/input.dart
+++ b/packages/zefyr/lib/src/widgets/input.dart
@@ -103,6 +103,11 @@ class InputConnectionController implements TextInputClient {
   }
 
   @override
+  void performPrivateCommand(String action, Map<String, dynamic> data) {
+    // no-op
+  }
+
+  @override
   void updateEditingValue(TextEditingValue value) {
     if (_sentRemoteValues.contains(value)) {
       /// There is a race condition in Flutter text input plugin where sending


### PR DESCRIPTION
The signature for `TextInputClient` has changed and now requires `performPrivateCommand` as well.

https://api.flutter.dev/flutter/services/TextInputClient/performPrivateCommand.html

```
../../../../.pub-cache/git/zefyr-0d69499582ee9ded8afa23b5ba3b0be8c51b7aed/packages/zefyr/lib/src/widgets/input.dart:11:7: Error: The non-abstract class 'InputConnectionController' is
    missing implementations for these members:
     - TextInputClient.performPrivateCommand
    Try to either
     - provide an implementation,
     - inherit an implementation from a superclass or mixin,
     - mark the class as abstract, or
     - provide a 'noSuchMethod' implementation.

    class InputConnectionController implements TextInputClient {
          ^^^^^^^^^^^^^^^^^^^^^^^^^
    ../../../../bin/flutter/packages/flutter/lib/src/services/text_input.dart:813:8: Context: 'TextInputClient.performPrivateCommand' is defined here.
      void performPrivateCommand(String action, Map<String, dynamic> data);
```