### PR TITLE
[1.0-dev] Proof of concept: AutoHideToolbar

### DIFF
--- a/packages/zefyr/example/lib/src/autohide_toolbar_view.dart
+++ b/packages/zefyr/example/lib/src/autohide_toolbar_view.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:zefyr/zefyr.dart';
+
+import 'scaffold.dart';
+
+class AutoHideToolbarView extends StatefulWidget {
+  @override
+  _AutoHideToolbarViewState createState() => _AutoHideToolbarViewState();
+}
+
+class _AutoHideToolbarViewState extends State<AutoHideToolbarView> {
+  final FocusNode _focusNode1 = FocusNode();
+  final FocusNode _focusNode2 = FocusNode();
+  final FocusNode _focusNode3 = FocusNode();
+  final _controller1 = ZefyrController();
+  final _controller2 = ZefyrController();
+  final _controller3 = ZefyrController();
+  @override
+  Widget build(BuildContext context) {
+    return DemoScaffold(
+      documentFilename: 'basics_read_only_view.note',
+      builder: _buildContent,
+      showToolbar: false,
+    );
+  }
+
+  Widget _buildContent(BuildContext context, ZefyrController controller) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          border: Border.all(color: Colors.grey.shade200),
+        ),
+        child: Column(
+          children: [
+            ListTile(title: Text('Editor 1')),
+            AutoHideToolbar(controller: _controller1, focusNode: _focusNode1),
+            ZefyrEditor(
+              controller: _controller1,
+              focusNode: _focusNode1,
+              expands: false,
+              padding: EdgeInsets.symmetric(horizontal: 8),
+            ),
+            ListTile(title: Text('Editor 2')),
+            AutoHideToolbar(controller: _controller2, focusNode: _focusNode2),
+            ZefyrEditor(
+              controller: _controller2,
+              focusNode: _focusNode2,
+              expands: false,
+              padding: EdgeInsets.symmetric(horizontal: 8),
+            ),
+            ListTile(title: Text('Editor 3')),
+            AutoHideToolbar(controller: _controller3, focusNode: _focusNode3),
+            ZefyrEditor(
+              controller: _controller3,
+              focusNode: _focusNode3,
+              expands: false,
+              padding: EdgeInsets.symmetric(horizontal: 8),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/zefyr/example/lib/src/home.dart
+++ b/packages/zefyr/example/lib/src/home.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:example/src/autohide_toolbar_view.dart';
 import 'package:example/src/read_only_view.dart';
 import 'package:file/local.dart';
 import 'package:flutter/material.dart';
@@ -125,6 +126,12 @@ class _HomePageState extends State<HomePage> {
           onTap: _readOnlyView,
         ),
         ListTile(
+          title: Text('¶   Autohide toolbar', style: itemStyle),
+          dense: true,
+          visualDensity: VisualDensity.compact,
+          onTap: _autoHideToolbarView,
+        ),
+        ListTile(
           title: Text('LAYOUT EXAMPLES', style: headerStyle),
           // dense: true,
           visualDensity: VisualDensity.compact,
@@ -205,6 +212,18 @@ class _HomePageState extends State<HomePage> {
         builder: (BuildContext context) => SettingsProvider(
           settings: _settings,
           child: ReadOnlyView(),
+        ),
+      ),
+    );
+  }
+
+  void _autoHideToolbarView() {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (BuildContext context) => SettingsProvider(
+          settings: _settings,
+          child: AutoHideToolbarView(),
         ),
       ),
     );

--- a/packages/zefyr/lib/src/widgets/autohide_toolbar.dart
+++ b/packages/zefyr/lib/src/widgets/autohide_toolbar.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:zefyr/zefyr.dart';
+
+class AutoHideToolbar extends StatefulWidget {
+  final ZefyrController controller;
+  final FocusNode focusNode;
+  const AutoHideToolbar(
+      {@required this.controller, @required this.focusNode, Key key})
+      : super(key: key);
+
+  @override
+  _AutoHideToolbarState createState() => _AutoHideToolbarState();
+}
+
+class _AutoHideToolbarState extends State<AutoHideToolbar> {
+  bool _activeMenu = false;
+  final _toolbarFocusNode = FocusNode();
+
+  void _onToggleMenu(bool active) {
+    setState(() {
+      _activeMenu = active;
+    });
+  }
+
+  _onFocusChange() {
+    setState(() => null);
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    widget.focusNode.addListener(_onFocusChange);
+    _toolbarFocusNode.addListener(_onFocusChange);
+  }
+
+  @override
+  void didUpdateWidget(covariant AutoHideToolbar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.focusNode != oldWidget.focusNode) {
+      oldWidget.focusNode.removeListener(_onFocusChange);
+      widget.focusNode.addListener(_onFocusChange);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final visible =
+        _toolbarFocusNode.hasFocus || widget.focusNode.hasFocus || _activeMenu;
+    print(
+        'ToobarFocus: ${_toolbarFocusNode.hasFocus} EditorFocus: ${widget.focusNode.hasFocus} ToolbarPopupFocus: ${_activeMenu}');
+    return Focus(
+        focusNode: _toolbarFocusNode,
+        child: Visibility(
+            visible: visible,
+            child: ZefyrToolbar.basic(
+                controller: widget.controller, onShowMenu: _onToggleMenu)));
+  }
+}

--- a/packages/zefyr/lib/src/widgets/editor_toolbar.dart
+++ b/packages/zefyr/lib/src/widgets/editor_toolbar.dart
@@ -569,7 +569,6 @@ class _ZDropdownButtonState<T> extends State<ZDropdownButton<T>> {
       color: popupMenuTheme.color, // widget.color ?? popupMenuTheme.color,
       // captureInheritedThemes: widget.captureInheritedThemes,
     ).then((T newValue) {
-      if (widget.onShowMenu != null) widget.onShowMenu(false);
       if (!mounted) return null;
       if (newValue == null) {
         // if (widget.onCanceled != null) widget.onCanceled();
@@ -578,6 +577,7 @@ class _ZDropdownButtonState<T> extends State<ZDropdownButton<T>> {
       if (widget.onSelected != null) {
         widget.onSelected(newValue);
       }
+      if (widget.onShowMenu != null) widget.onShowMenu(false);
     });
   }
 

--- a/packages/zefyr/lib/src/widgets/editor_toolbar.dart
+++ b/packages/zefyr/lib/src/widgets/editor_toolbar.dart
@@ -279,8 +279,10 @@ Widget defaultToggleStyleButtonBuilder(
 // TODO: Add "dense" parameter which if set to true changes the button to use an icon instead of text (useful for mobile layouts)
 class SelectHeadingStyleButton extends StatefulWidget {
   final ZefyrController controller;
+  final void Function(bool) onShowMenu;
 
-  const SelectHeadingStyleButton({Key key, @required this.controller})
+  const SelectHeadingStyleButton(
+      {Key key, @required this.controller, this.onShowMenu})
       : super(key: key);
 
   @override
@@ -329,56 +331,58 @@ class _SelectHeadingStyleButtonState extends State<SelectHeadingStyleButton> {
     super.dispose();
   }
 
+  Widget _selectHeadingStyleButtonBuilder(
+    BuildContext context,
+  ) {
+    final style = TextStyle(fontSize: 12);
+
+    final valueToText = {
+      NotusAttribute.heading.unset: 'Normal text',
+      NotusAttribute.heading.level1: 'Heading 1',
+      NotusAttribute.heading.level2: 'Heading 2',
+      NotusAttribute.heading.level3: 'Heading 3',
+    };
+
+    return ZDropdownButton<NotusAttribute>(
+      highlightElevation: 0,
+      hoverElevation: 0,
+      height: 32,
+      onShowMenu: widget.onShowMenu,
+      child: Text(
+        valueToText[_value],
+        style: TextStyle(fontSize: 12, fontWeight: FontWeight.w600),
+      ),
+      initialValue: _value,
+      items: [
+        PopupMenuItem(
+          child: Text(valueToText[NotusAttribute.heading.unset], style: style),
+          value: NotusAttribute.heading.unset,
+          height: 32,
+        ),
+        PopupMenuItem(
+          child: Text(valueToText[NotusAttribute.heading.level1], style: style),
+          value: NotusAttribute.heading.level1,
+          height: 32,
+        ),
+        PopupMenuItem(
+          child: Text(valueToText[NotusAttribute.heading.level2], style: style),
+          value: NotusAttribute.heading.level2,
+          height: 32,
+        ),
+        PopupMenuItem(
+          child: Text(valueToText[NotusAttribute.heading.level3], style: style),
+          value: NotusAttribute.heading.level3,
+          height: 32,
+        ),
+      ],
+      onSelected: _selectAttribute,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-    return _selectHeadingStyleButtonBuilder(context, _value, _selectAttribute);
+    return _selectHeadingStyleButtonBuilder(context);
   }
-}
-
-Widget _selectHeadingStyleButtonBuilder(BuildContext context,
-    NotusAttribute value, ValueChanged<NotusAttribute> onSelected) {
-  final style = TextStyle(fontSize: 12);
-
-  final valueToText = {
-    NotusAttribute.heading.unset: 'Normal text',
-    NotusAttribute.heading.level1: 'Heading 1',
-    NotusAttribute.heading.level2: 'Heading 2',
-    NotusAttribute.heading.level3: 'Heading 3',
-  };
-
-  return ZDropdownButton<NotusAttribute>(
-    highlightElevation: 0,
-    hoverElevation: 0,
-    height: 32,
-    child: Text(
-      valueToText[value],
-      style: TextStyle(fontSize: 12, fontWeight: FontWeight.w600),
-    ),
-    initialValue: value,
-    items: [
-      PopupMenuItem(
-        child: Text(valueToText[NotusAttribute.heading.unset], style: style),
-        value: NotusAttribute.heading.unset,
-        height: 32,
-      ),
-      PopupMenuItem(
-        child: Text(valueToText[NotusAttribute.heading.level1], style: style),
-        value: NotusAttribute.heading.level1,
-        height: 32,
-      ),
-      PopupMenuItem(
-        child: Text(valueToText[NotusAttribute.heading.level2], style: style),
-        value: NotusAttribute.heading.level2,
-        height: 32,
-      ),
-      PopupMenuItem(
-        child: Text(valueToText[NotusAttribute.heading.level3], style: style),
-        value: NotusAttribute.heading.level3,
-        height: 32,
-      ),
-    ],
-    onSelected: onSelected,
-  );
 }
 
 class ZefyrToolbar extends StatefulWidget implements PreferredSizeWidget {
@@ -386,7 +390,10 @@ class ZefyrToolbar extends StatefulWidget implements PreferredSizeWidget {
 
   const ZefyrToolbar({Key key, @required this.children}) : super(key: key);
 
-  factory ZefyrToolbar.basic({Key key, @required ZefyrController controller}) {
+  factory ZefyrToolbar.basic(
+      {Key key,
+      @required ZefyrController controller,
+      void Function(bool) onShowMenu}) {
     return ZefyrToolbar(key: key, children: [
       ToggleStyleButton(
         attribute: NotusAttribute.bold,
@@ -400,7 +407,7 @@ class ZefyrToolbar extends StatefulWidget implements PreferredSizeWidget {
         controller: controller,
       ),
       VerticalDivider(indent: 16, endIndent: 16, color: Colors.grey.shade400),
-      SelectHeadingStyleButton(controller: controller),
+      SelectHeadingStyleButton(controller: controller, onShowMenu: onShowMenu),
       VerticalDivider(indent: 16, endIndent: 16, color: Colors.grey.shade400),
       ToggleStyleButton(
         attribute: NotusAttribute.block.numberList,
@@ -501,6 +508,7 @@ class ZDropdownButton<T> extends StatefulWidget {
   final T initialValue;
   final List<PopupMenuEntry<T>> items;
   final ValueChanged<T> onSelected;
+  final void Function(bool) onShowMenu;
 
   const ZDropdownButton({
     Key key,
@@ -512,6 +520,7 @@ class ZDropdownButton<T> extends StatefulWidget {
     @required this.initialValue,
     @required this.items,
     @required this.onSelected,
+    this.onShowMenu,
   }) : super(key: key);
 
   @override
@@ -549,6 +558,7 @@ class _ZDropdownButtonState<T> extends State<ZDropdownButton<T>> {
       ),
       Offset.zero & overlay.size,
     );
+    if (widget.onShowMenu != null) widget.onShowMenu(true);
     showMenu<T>(
       context: context,
       elevation: 4, // widget.elevation ?? popupMenuTheme.elevation,
@@ -559,6 +569,7 @@ class _ZDropdownButtonState<T> extends State<ZDropdownButton<T>> {
       color: popupMenuTheme.color, // widget.color ?? popupMenuTheme.color,
       // captureInheritedThemes: widget.captureInheritedThemes,
     ).then((T newValue) {
+      if (widget.onShowMenu != null) widget.onShowMenu(false);
       if (!mounted) return null;
       if (newValue == null) {
         // if (widget.onCanceled != null) widget.onCanceled();

--- a/packages/zefyr/lib/zefyr.dart
+++ b/packages/zefyr/lib/zefyr.dart
@@ -17,3 +17,4 @@ export 'src/widgets/editor_toolbar.dart';
 export 'src/widgets/field.dart';
 export 'src/widgets/text_line.dart';
 export 'src/widgets/theme.dart';
+export 'src/widgets/autohide_toolbar.dart';


### PR DESCRIPTION
This code is not ready for being pushed yet.

I dont know which approach is the best...

@pulyaevskiy are you interested by the feature?

Do you have any idea how to achieve this cleanly? (not sure if we can detect modal automatically).

For now I pass a callback to toolbar widgets that sets a bool on and off when showing a menu. 
There is still a state, when discarding the menu by clicking outside, where the menu is not active, and neither the toolbar nor the editor have the focus yet... :/

