### PR TITLE
Hide selection handle when the current selection is collapsed

### DIFF
--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -990,7 +990,7 @@ class RawEditorState extends EditorState
           dragStartBehavior: DragStartBehavior.start,
           // onSelectionHandleTapped: widget.onSelectionHandleTapped,
         );
-        _selectionOverlay.handlesVisible = widget.showSelectionHandles;
+        _selectionOverlay.handlesVisible = _shouldShowSelectionHandles();
         _selectionOverlay.showHandles();
         // if (widget.onSelectionChanged != null)
         //   widget.onSelectionChanged(selection, cause);

--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -824,10 +824,8 @@ class RawEditorState extends EditorState
   }
 
   bool _shouldShowSelectionHandles() {
-    if (widget.readOnly && widget.controller.selection.isCollapsed) {
-      return false;
-    }
-    return widget.showSelectionHandles;
+    return widget.showSelectionHandles &&
+        !widget.controller.selection.isCollapsed;
   }
 
   @override


### PR DESCRIPTION

@cgestes You introduced `_shouldShowSelectionHandles()` in #410 so you might have an opinion on this.

Selection behaviour still isn't on par with pre-v1 Zefyr but this was the first difference I noticed.

# Before

![before](https://user-images.githubusercontent.com/33752528/99159525-f5946f00-26d4-11eb-8a30-40a7e17883c3.gif)

# After
![after](https://user-images.githubusercontent.com/33752528/99159526-f6c59c00-26d4-11eb-8ae7-e1b6fadaa76a.gif)
