### PR TITLE
Added text direction feature

### DIFF
--- a/packages/notus/lib/src/document/attributes.dart
+++ b/packages/notus/lib/src/document/attributes.dart
@@ -72,6 +72,7 @@ abstract class NotusAttributeBuilder<T> implements NotusAttributeKey<T> {
 ///   * [NotusAttribute.link]
 ///   * [NotusAttribute.heading]
 ///   * [NotusAttribute.block]
+///   * [NotusAttribute.direction]
 class NotusAttribute<T> implements NotusAttributeBuilder<T> {
   static final Map<String, NotusAttributeBuilder> _registry = {
     NotusAttribute.bold.key: NotusAttribute.bold,
@@ -81,6 +82,7 @@ class NotusAttribute<T> implements NotusAttributeBuilder<T> {
     NotusAttribute.link.key: NotusAttribute.link,
     NotusAttribute.heading.key: NotusAttribute.heading,
     NotusAttribute.block.key: NotusAttribute.block,
+    NotusAttribute.direction.key: NotusAttribute.direction,
   };
 
   // Inline attributes
@@ -131,6 +133,15 @@ class NotusAttribute<T> implements NotusAttributeBuilder<T> {
 
   /// Alias for [NotusAttribute.block.code].
   static NotusAttribute<String> get code => block.code;
+
+  /// Direction attribute
+  static const direction = DirectionAttributeBuilder._();
+
+  /// Alias for [NotusAttribute.direction.ltr].
+  static NotusAttribute<String> get rtl => direction.rtl;
+
+  /// Alias for [NotusAttribute.direction.ltr].
+  static NotusAttribute<String> get ltr => direction.ltr;
 
   static NotusAttribute _fromKeyValue(String key, dynamic value) {
     if (!_registry.containsKey(key)) {
@@ -398,4 +409,14 @@ class BlockAttributeBuilder extends NotusAttributeBuilder<String> {
   /// Formats a block of lines as a quote.
   NotusAttribute<String> get quote =>
       NotusAttribute<String>._(key, scope, 'quote');
+}
+
+class DirectionAttributeBuilder extends NotusAttributeBuilder<String> {
+  static const _kDirection = 'direction';
+  const DirectionAttributeBuilder._()
+      : super._(_kDirection, NotusAttributeScope.line);
+
+  NotusAttribute<String> get rtl => NotusAttribute<String>._(key, scope, 'rtl');
+
+  NotusAttribute<String> get ltr => NotusAttribute<String>._(key, scope, 'ltr');
 }

--- a/packages/notus/lib/src/document/attributes.dart
+++ b/packages/notus/lib/src/document/attributes.dart
@@ -137,11 +137,8 @@ class NotusAttribute<T> implements NotusAttributeBuilder<T> {
   /// Direction attribute
   static const direction = DirectionAttributeBuilder._();
 
-  /// Alias for [NotusAttribute.direction.ltr].
+  /// Alias for [NotusAttribute.direction.rtl].
   static NotusAttribute<String> get rtl => direction.rtl;
-
-  /// Alias for [NotusAttribute.direction.ltr].
-  static NotusAttribute<String> get ltr => direction.ltr;
 
   static NotusAttribute _fromKeyValue(String key, dynamic value) {
     if (!_registry.containsKey(key)) {
@@ -417,6 +414,4 @@ class DirectionAttributeBuilder extends NotusAttributeBuilder<String> {
       : super._(_kDirection, NotusAttributeScope.line);
 
   NotusAttribute<String> get rtl => NotusAttribute<String>._(key, scope, 'rtl');
-
-  NotusAttribute<String> get ltr => NotusAttribute<String>._(key, scope, 'ltr');
 }

--- a/packages/zefyr/lib/src/rendering/editable_text_block.dart
+++ b/packages/zefyr/lib/src/rendering/editable_text_block.dart
@@ -17,10 +17,9 @@ class RenderEditableTextBlock extends RenderEditableContainerBox
     required TextDirection textDirection,
     required EdgeInsetsGeometry padding,
     required Decoration decoration,
-    ImageConfiguration configuration = ImageConfiguration.empty,
     EdgeInsets contentPadding = EdgeInsets.zero,
   })  : _decoration = decoration,
-        _configuration = configuration,
+        _configuration = ImageConfiguration(textDirection: textDirection),
         _savedPadding = padding,
         _contentPadding = contentPadding,
         super(

--- a/packages/zefyr/lib/src/rendering/editable_text_line.dart
+++ b/packages/zefyr/lib/src/rendering/editable_text_line.dart
@@ -633,7 +633,8 @@ class RenderEditableTextLine extends RenderEditableBox {
           maxHeight: body!.size.height);
       leading!.layout(leadingConstraints, parentUsesSize: true);
       final parentData = leading!.parentData as BoxParentData;
-      parentData.offset = Offset(0.0, _resolvedPadding!.top);
+      final dxOffset = textDirection == TextDirection.rtl ? body!.size.width : 0.0;
+      parentData.offset = Offset(dxOffset, _resolvedPadding!.top);
     }
 
     size = constraints.constrain(Size(

--- a/packages/zefyr/lib/src/widgets/editable_text_block.dart
+++ b/packages/zefyr/lib/src/widgets/editable_text_block.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:notus/notus.dart';
+import 'package:zefyr/util.dart';
 
 import '../rendering/editable_text_block.dart';
 import 'cursor.dart';
@@ -49,14 +50,6 @@ class EditableTextBlock extends StatelessWidget {
     );
   }
 
-  TextDirection getTextDirectionForNode(BuildContext context, StyledNode node) {
-    final preferredDirection = node.style.get(NotusAttribute.direction);
-    if (preferredDirection == NotusAttribute.rtl) {
-      return TextDirection.rtl;
-    }
-    return TextDirection.ltr;
-  }
-
   List<Widget> _buildChildren(BuildContext context) {
     final theme = ZefyrTheme.of(context)!;
     final count = node.children.length;
@@ -64,8 +57,7 @@ class EditableTextBlock extends StatelessWidget {
     var index = 0;
     for (final line in node.children) {
       index++;
-      final nodeTextDirection =
-          getTextDirectionForNode(context, line as LineNode);
+      final nodeTextDirection = getDirectionOfNode(line as LineNode);
       children.add(Directionality(
         textDirection: nodeTextDirection,
         child: EditableTextLine(

--- a/packages/zefyr/lib/src/widgets/editable_text_block.dart
+++ b/packages/zefyr/lib/src/widgets/editable_text_block.dart
@@ -11,7 +11,6 @@ import 'theme.dart';
 
 class EditableTextBlock extends StatelessWidget {
   final BlockNode node;
-  final TextDirection textDirection;
   final VerticalSpacing spacing;
   final CursorController cursorController;
   final TextSelection selection;
@@ -24,7 +23,6 @@ class EditableTextBlock extends StatelessWidget {
   EditableTextBlock({
     Key? key,
     required this.node,
-    required this.textDirection,
     required this.spacing,
     required this.cursorController,
     required this.selection,
@@ -42,7 +40,6 @@ class EditableTextBlock extends StatelessWidget {
     final theme = ZefyrTheme.of(context)!;
     return _EditableBlock(
       node: node,
-      textDirection: textDirection,
       padding: spacing,
       contentPadding: contentPadding,
       decoration: _getDecorationForBlock(node, theme) ?? BoxDecoration(),
@@ -62,7 +59,6 @@ class EditableTextBlock extends StatelessWidget {
         textDirection: nodeTextDirection,
         child: EditableTextLine(
           node: line,
-          textDirection: nodeTextDirection,
           spacing: _getSpacingForLine(line, index, count, theme),
           leading: _buildLeading(context, line, index, count),
           indentWidth: _getIndentWidth(),
@@ -70,7 +66,6 @@ class EditableTextBlock extends StatelessWidget {
           body: TextLine(
             node: line,
             embedBuilder: embedBuilder,
-            textDirection: nodeTextDirection,
           ),
           cursorController: cursorController,
           selection: selection,
@@ -185,7 +180,6 @@ class EditableTextBlock extends StatelessWidget {
 
 class _EditableBlock extends MultiChildRenderObjectWidget {
   final BlockNode node;
-  final TextDirection textDirection;
   final VerticalSpacing padding;
   final Decoration decoration;
   final EdgeInsets? contentPadding;
@@ -193,7 +187,6 @@ class _EditableBlock extends MultiChildRenderObjectWidget {
   _EditableBlock({
     Key? key,
     required this.node,
-    required this.textDirection,
     required this.decoration,
     required List<Widget> children,
     this.contentPadding,
@@ -209,7 +202,7 @@ class _EditableBlock extends MultiChildRenderObjectWidget {
   RenderEditableTextBlock createRenderObject(BuildContext context) {
     return RenderEditableTextBlock(
       node: node,
-      textDirection: textDirection,
+      textDirection: Directionality.of(context),
       padding: _padding,
       decoration: decoration,
       contentPadding: _contentPadding,
@@ -220,7 +213,7 @@ class _EditableBlock extends MultiChildRenderObjectWidget {
   void updateRenderObject(
       BuildContext context, covariant RenderEditableTextBlock renderObject) {
     renderObject.node = node;
-    renderObject.textDirection = textDirection;
+    renderObject.textDirection = Directionality.of(context);
     renderObject.padding = _padding;
     renderObject.decoration = decoration;
     renderObject.contentPadding = _contentPadding;

--- a/packages/zefyr/lib/src/widgets/editable_text_block.dart
+++ b/packages/zefyr/lib/src/widgets/editable_text_block.dart
@@ -49,6 +49,16 @@ class EditableTextBlock extends StatelessWidget {
     );
   }
 
+  TextDirection getTextDirectionForNode(BuildContext context, StyledNode node) {
+    final preferredDirection = node.style.get(NotusAttribute.direction);
+    if (preferredDirection == NotusAttribute.rtl) {
+      return TextDirection.rtl;
+    } else if (preferredDirection == NotusAttribute.ltr) {
+      return TextDirection.ltr;
+    }
+    return Directionality.of(context);
+  }
+
   List<Widget> _buildChildren(BuildContext context) {
     final theme = ZefyrTheme.of(context)!;
     final count = node.children.length;
@@ -56,17 +66,19 @@ class EditableTextBlock extends StatelessWidget {
     var index = 0;
     for (final line in node.children) {
       index++;
+      final nodeTextDirection =
+          getTextDirectionForNode(context, line as LineNode);
       children.add(EditableTextLine(
-        node: line as LineNode,
-        textDirection: textDirection,
+        node: line,
+        textDirection: nodeTextDirection,
         spacing: _getSpacingForLine(line, index, count, theme),
         leading: _buildLeading(context, line, index, count),
         indentWidth: _getIndentWidth(),
         devicePixelRatio: MediaQuery.of(context).devicePixelRatio,
         body: TextLine(
           node: line,
-          textDirection: textDirection,
           embedBuilder: embedBuilder,
+          textDirection: nodeTextDirection,
         ),
         cursorController: cursorController,
         selection: selection,

--- a/packages/zefyr/lib/src/widgets/editable_text_block.dart
+++ b/packages/zefyr/lib/src/widgets/editable_text_block.dart
@@ -53,10 +53,8 @@ class EditableTextBlock extends StatelessWidget {
     final preferredDirection = node.style.get(NotusAttribute.direction);
     if (preferredDirection == NotusAttribute.rtl) {
       return TextDirection.rtl;
-    } else if (preferredDirection == NotusAttribute.ltr) {
-      return TextDirection.ltr;
     }
-    return Directionality.of(context);
+    return TextDirection.ltr;
   }
 
   List<Widget> _buildChildren(BuildContext context) {
@@ -68,23 +66,26 @@ class EditableTextBlock extends StatelessWidget {
       index++;
       final nodeTextDirection =
           getTextDirectionForNode(context, line as LineNode);
-      children.add(EditableTextLine(
-        node: line,
+      children.add(Directionality(
         textDirection: nodeTextDirection,
-        spacing: _getSpacingForLine(line, index, count, theme),
-        leading: _buildLeading(context, line, index, count),
-        indentWidth: _getIndentWidth(),
-        devicePixelRatio: MediaQuery.of(context).devicePixelRatio,
-        body: TextLine(
+        child: EditableTextLine(
           node: line,
-          embedBuilder: embedBuilder,
           textDirection: nodeTextDirection,
+          spacing: _getSpacingForLine(line, index, count, theme),
+          leading: _buildLeading(context, line, index, count),
+          indentWidth: _getIndentWidth(),
+          devicePixelRatio: MediaQuery.of(context).devicePixelRatio,
+          body: TextLine(
+            node: line,
+            embedBuilder: embedBuilder,
+            textDirection: nodeTextDirection,
+          ),
+          cursorController: cursorController,
+          selection: selection,
+          selectionColor: selectionColor,
+          enableInteractiveSelection: enableInteractiveSelection,
+          hasFocus: hasFocus,
         ),
-        cursorController: cursorController,
-        selection: selection,
-        selectionColor: selectionColor,
-        enableInteractiveSelection: enableInteractiveSelection,
-        hasFocus: hasFocus,
       ));
     }
     return children.toList(growable: false);

--- a/packages/zefyr/lib/src/widgets/editable_text_line.dart
+++ b/packages/zefyr/lib/src/widgets/editable_text_line.dart
@@ -26,7 +26,6 @@ class EditableTextLine extends RenderObjectWidget {
   /// Space above and below [body] of this text line.
   final VerticalSpacing spacing;
 
-  final TextDirection textDirection;
   final CursorController cursorController;
   final TextSelection selection;
   final Color selectionColor;
@@ -39,7 +38,6 @@ class EditableTextLine extends RenderObjectWidget {
     Key? key,
     required this.node,
     required this.body,
-    required this.textDirection,
     required this.cursorController,
     required this.selection,
     required this.selectionColor,
@@ -65,7 +63,7 @@ class EditableTextLine extends RenderObjectWidget {
     return RenderEditableTextLine(
       node: node,
       padding: _padding,
-      textDirection: textDirection,
+      textDirection: Directionality.of(context),
       cursorController: cursorController,
       selection: selection,
       selectionColor: selectionColor,
@@ -80,7 +78,7 @@ class EditableTextLine extends RenderObjectWidget {
       BuildContext context, covariant RenderEditableTextLine renderObject) {
     renderObject.node = node;
     renderObject.padding = _padding;
-    renderObject.textDirection = textDirection;
+    renderObject.textDirection = Directionality.of(context);
     renderObject.cursorController = cursorController;
     renderObject.selection = selection;
     renderObject.selectionColor = selectionColor;

--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -1155,14 +1155,12 @@ class RawEditorState extends EditorState
     );
   }
 
-  TextDirection getTextDirectionForStyledNode(StyledNode node){
+  TextDirection getTextDirectionForStyledNode(StyledNode node) {
     final preferredDirection = node.style.get(NotusAttribute.direction);
     if (preferredDirection == NotusAttribute.rtl) {
       return TextDirection.rtl;
-    } else if (preferredDirection == NotusAttribute.ltr) {
-      return TextDirection.ltr;
     }
-    return _textDirection;
+    return TextDirection.ltr;
   }
 
   List<Widget> _buildChildren(BuildContext context) {

--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -11,6 +11,7 @@ import 'package:flutter/widgets.dart';
 import 'package:notus/notus.dart';
 import 'package:zefyr/src/widgets/baseline_proxy.dart';
 import 'package:zefyr/src/widgets/single_child_scroll_view.dart';
+import 'package:zefyr/util.dart';
 
 import '../rendering/editor.dart';
 import '../services/keyboard.dart';
@@ -1155,19 +1156,11 @@ class RawEditorState extends EditorState
     );
   }
 
-  TextDirection getTextDirectionForStyledNode(StyledNode node) {
-    final preferredDirection = node.style.get(NotusAttribute.direction);
-    if (preferredDirection == NotusAttribute.rtl) {
-      return TextDirection.rtl;
-    }
-    return TextDirection.ltr;
-  }
-
   List<Widget> _buildChildren(BuildContext context) {
     final result = <Widget>[];
     for (final node in widget.controller.document.root.children) {
       if (node is LineNode) {
-        final textDirection = getTextDirectionForStyledNode(node);
+        final textDirection = getDirectionOfNode(node);
         result.add(EditableTextLine(
           node: node,
           textDirection: textDirection,
@@ -1187,7 +1180,7 @@ class RawEditorState extends EditorState
         ));
       } else if (node is BlockNode) {
         final block = node.style.get(NotusAttribute.block);
-        final textDirection = getTextDirectionForStyledNode(node);
+        final textDirection = getDirectionOfNode(node);
         result.add(EditableTextBlock(
           node: node,
           textDirection: textDirection,

--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -1155,13 +1155,24 @@ class RawEditorState extends EditorState
     );
   }
 
+  TextDirection getTextDirectionForStyledNode(StyledNode node){
+    final preferredDirection = node.style.get(NotusAttribute.direction);
+    if (preferredDirection == NotusAttribute.rtl) {
+      return TextDirection.rtl;
+    } else if (preferredDirection == NotusAttribute.ltr) {
+      return TextDirection.ltr;
+    }
+    return _textDirection;
+  }
+
   List<Widget> _buildChildren(BuildContext context) {
     final result = <Widget>[];
     for (final node in widget.controller.document.root.children) {
       if (node is LineNode) {
+        final textDirection = getTextDirectionForStyledNode(node);
         result.add(EditableTextLine(
           node: node,
-          textDirection: _textDirection,
+          textDirection: textDirection,
           indentWidth: 0,
           spacing: _getSpacingForLine(node, _themeData),
           cursorController: _cursorController,
@@ -1170,17 +1181,18 @@ class RawEditorState extends EditorState
           enableInteractiveSelection: widget.enableInteractiveSelection,
           body: TextLine(
             node: node,
-            textDirection: _textDirection,
             embedBuilder: widget.embedBuilder,
+            textDirection: textDirection,
           ),
           hasFocus: _hasFocus,
           devicePixelRatio: MediaQuery.of(context).devicePixelRatio,
         ));
       } else if (node is BlockNode) {
         final block = node.style.get(NotusAttribute.block);
+        final textDirection = getTextDirectionForStyledNode(node);
         result.add(EditableTextBlock(
           node: node,
-          textDirection: _textDirection,
+          textDirection: textDirection,
           spacing: _getSpacingForBlock(node, _themeData),
           cursorController: _cursorController,
           selection: widget.controller.selection,

--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -1160,40 +1160,41 @@ class RawEditorState extends EditorState
     final result = <Widget>[];
     for (final node in widget.controller.document.root.children) {
       if (node is LineNode) {
-        final textDirection = getDirectionOfNode(node);
-        result.add(EditableTextLine(
-          node: node,
-          textDirection: textDirection,
-          indentWidth: 0,
-          spacing: _getSpacingForLine(node, _themeData),
-          cursorController: _cursorController,
-          selection: widget.controller.selection,
-          selectionColor: widget.selectionColor,
-          enableInteractiveSelection: widget.enableInteractiveSelection,
-          body: TextLine(
+        result.add(Directionality(
+          textDirection: getDirectionOfNode(node),
+          child: EditableTextLine(
             node: node,
-            embedBuilder: widget.embedBuilder,
-            textDirection: textDirection,
+            indentWidth: 0,
+            spacing: _getSpacingForLine(node, _themeData),
+            cursorController: _cursorController,
+            selection: widget.controller.selection,
+            selectionColor: widget.selectionColor,
+            enableInteractiveSelection: widget.enableInteractiveSelection,
+            body: TextLine(
+              node: node,
+              embedBuilder: widget.embedBuilder,
+            ),
+            hasFocus: _hasFocus,
+            devicePixelRatio: MediaQuery.of(context).devicePixelRatio,
           ),
-          hasFocus: _hasFocus,
-          devicePixelRatio: MediaQuery.of(context).devicePixelRatio,
         ));
       } else if (node is BlockNode) {
         final block = node.style.get(NotusAttribute.block);
-        final textDirection = getDirectionOfNode(node);
-        result.add(EditableTextBlock(
-          node: node,
-          textDirection: textDirection,
-          spacing: _getSpacingForBlock(node, _themeData),
-          cursorController: _cursorController,
-          selection: widget.controller.selection,
-          selectionColor: widget.selectionColor,
-          enableInteractiveSelection: widget.enableInteractiveSelection,
-          hasFocus: _hasFocus,
-          contentPadding: (block == NotusAttribute.block.code)
-              ? EdgeInsets.all(16.0)
-              : null,
-          embedBuilder: widget.embedBuilder,
+        result.add(Directionality(
+          textDirection: getDirectionOfNode(node),
+          child: EditableTextBlock(
+            node: node,
+            spacing: _getSpacingForBlock(node, _themeData),
+            cursorController: _cursorController,
+            selection: widget.controller.selection,
+            selectionColor: widget.selectionColor,
+            enableInteractiveSelection: widget.enableInteractiveSelection,
+            hasFocus: _hasFocus,
+            contentPadding: (block == NotusAttribute.block.code)
+                ? EdgeInsets.all(16.0)
+                : null,
+            embedBuilder: widget.embedBuilder,
+          ),
         ));
       } else {
         throw StateError('Unreachable.');

--- a/packages/zefyr/lib/src/widgets/editor_toolbar.dart
+++ b/packages/zefyr/lib/src/widgets/editor_toolbar.dart
@@ -445,15 +445,6 @@ class ZefyrToolbar extends StatefulWidget implements PreferredSizeWidget {
       Visibility(
         visible: !hideDirection,
         child: ToggleStyleButton(
-          attribute: NotusAttribute.ltr,
-          icon: Icons.format_textdirection_l_to_r,
-          controller: controller,
-        ),
-      ),
-      SizedBox(width: 1),
-      Visibility(
-        visible: !hideDirection,
-        child: ToggleStyleButton(
           attribute: NotusAttribute.rtl,
           icon: Icons.format_textdirection_r_to_l,
           controller: controller,

--- a/packages/zefyr/lib/src/widgets/editor_toolbar.dart
+++ b/packages/zefyr/lib/src/widgets/editor_toolbar.dart
@@ -386,20 +386,22 @@ class ZefyrToolbar extends StatefulWidget implements PreferredSizeWidget {
 
   const ZefyrToolbar({Key? key, required this.children}) : super(key: key);
 
-  factory ZefyrToolbar.basic(
-      {Key? key,
-      required ZefyrController controller,
-      bool hideBoldButton = false,
-      bool hideItalicButton = false,
-      bool hideUnderLineButton = false,
-      bool hideStrikeThrough = false,
-      bool hideHeadingStyle = false,
-      bool hideListNumbers = false,
-      bool hideListBullets = false,
-      bool hideCodeBlock = false,
-      bool hideQuote = false,
-      bool hideLink = false,
-      bool hideHorizontalRule = false}) {
+  factory ZefyrToolbar.basic({
+    Key? key,
+    required ZefyrController controller,
+    bool hideBoldButton = false,
+    bool hideItalicButton = false,
+    bool hideUnderLineButton = false,
+    bool hideStrikeThrough = false,
+    bool hideHeadingStyle = false,
+    bool hideListNumbers = false,
+    bool hideListBullets = false,
+    bool hideCodeBlock = false,
+    bool hideQuote = false,
+    bool hideLink = false,
+    bool hideHorizontalRule = false,
+    bool hideDirection = false,
+  }) {
     return ZefyrToolbar(key: key, children: [
       Visibility(
         visible: !hideBoldButton,
@@ -433,6 +435,27 @@ class ZefyrToolbar extends StatefulWidget implements PreferredSizeWidget {
         child: ToggleStyleButton(
           attribute: NotusAttribute.strikethrough,
           icon: Icons.format_strikethrough,
+          controller: controller,
+        ),
+      ),
+      Visibility(
+          visible: !hideDirection,
+          child: VerticalDivider(
+              indent: 16, endIndent: 16, color: Colors.grey.shade400)),
+      Visibility(
+        visible: !hideDirection,
+        child: ToggleStyleButton(
+          attribute: NotusAttribute.ltr,
+          icon: Icons.format_textdirection_l_to_r,
+          controller: controller,
+        ),
+      ),
+      SizedBox(width: 1),
+      Visibility(
+        visible: !hideDirection,
+        child: ToggleStyleButton(
+          attribute: NotusAttribute.rtl,
+          icon: Icons.format_textdirection_r_to_l,
           controller: controller,
         ),
       ),

--- a/packages/zefyr/lib/src/widgets/rich_text_proxy.dart
+++ b/packages/zefyr/lib/src/widgets/rich_text_proxy.dart
@@ -7,7 +7,6 @@ class RichTextProxy extends SingleChildRenderObjectWidget {
   RichTextProxy({
     required RichText child,
     required this.textStyle,
-    required this.textDirection,
     required this.locale,
     required this.strutStyle,
     this.textScaleFactor = 1.0,
@@ -16,7 +15,6 @@ class RichTextProxy extends SingleChildRenderObjectWidget {
   }) : super(child: child);
 
   final TextStyle textStyle;
-  final TextDirection? textDirection;
   final double textScaleFactor;
   final Locale? locale;
   final StrutStyle strutStyle;
@@ -27,7 +25,7 @@ class RichTextProxy extends SingleChildRenderObjectWidget {
   RenderParagraphProxy createRenderObject(BuildContext context) {
     return RenderParagraphProxy(
       textStyle: textStyle,
-      textDirection: textDirection,
+      textDirection: Directionality.of(context),
       textScaleFactor: textScaleFactor,
       locale: locale,
       strutStyle: strutStyle,
@@ -40,7 +38,7 @@ class RichTextProxy extends SingleChildRenderObjectWidget {
   void updateRenderObject(
       BuildContext context, covariant RenderParagraphProxy renderObject) {
     renderObject.textStyle = textStyle;
-    renderObject.textDirection = textDirection!;
+    renderObject.textDirection = Directionality.of(context);
     renderObject.textScaleFactor = textScaleFactor;
     renderObject.locale = locale;
     renderObject.strutStyle = strutStyle;

--- a/packages/zefyr/lib/src/widgets/text_line.dart
+++ b/packages/zefyr/lib/src/widgets/text_line.dart
@@ -14,14 +14,14 @@ import 'theme.dart';
 class TextLine extends StatelessWidget {
   /// Line of text represented by this widget.
   final LineNode node;
-  final TextDirection? textDirection;
+  final TextDirection textDirection;
   final ZefyrEmbedBuilder embedBuilder;
 
   const TextLine({
     Key? key,
     required this.node,
     required this.embedBuilder,
-    this.textDirection,
+    required this.textDirection,
   }) : super(key: key);
 
   @override

--- a/packages/zefyr/lib/src/widgets/text_line.dart
+++ b/packages/zefyr/lib/src/widgets/text_line.dart
@@ -14,14 +14,12 @@ import 'theme.dart';
 class TextLine extends StatelessWidget {
   /// Line of text represented by this widget.
   final LineNode node;
-  final TextDirection textDirection;
   final ZefyrEmbedBuilder embedBuilder;
 
   const TextLine({
     Key? key,
     required this.node,
     required this.embedBuilder,
-    required this.textDirection,
   }) : super(key: key);
 
   @override
@@ -37,12 +35,10 @@ class TextLine extends StatelessWidget {
         StrutStyle.fromTextStyle(text.style!, forceStrutHeight: true);
     return RichTextProxy(
       textStyle: text.style!,
-      textDirection: textDirection,
       strutStyle: strutStyle,
       locale: Localizations.maybeLocaleOf(context),
       child: RichText(
         text: buildText(context, node),
-        textDirection: textDirection,
         strutStyle: strutStyle,
         textScaleFactor: MediaQuery.textScaleFactorOf(context),
       ),

--- a/packages/zefyr/lib/src/widgets/theme.dart
+++ b/packages/zefyr/lib/src/widgets/theme.dart
@@ -184,8 +184,8 @@ class ZefyrThemeData {
         spacing: baseSpacing,
         lineSpacing: VerticalSpacing(top: 6, bottom: 2),
         decoration: BoxDecoration(
-          border: Border(
-            left: BorderSide(width: 4, color: Colors.grey.shade300),
+          border: BorderDirectional(
+            start: BorderSide(width: 4, color: Colors.grey.shade300),
           ),
         ),
       ),

--- a/packages/zefyr/lib/util.dart
+++ b/packages/zefyr/lib/util.dart
@@ -6,7 +6,9 @@
 library zefyr.util;
 
 import 'dart:math' as math;
+import 'dart:ui';
 
+import 'package:notus/notus.dart';
 import 'package:quill_delta/quill_delta.dart';
 
 export 'src/fast_diff.dart';
@@ -38,4 +40,12 @@ int getPositionDelta(Delta user, Delta actual) {
     }
   }
   return diff;
+}
+
+TextDirection getDirectionOfNode(StyledNode node) {
+  final direction = node.style.get(NotusAttribute.direction);
+  if (direction == NotusAttribute.rtl) {
+    return TextDirection.rtl;
+  }
+  return TextDirection.ltr;
 }


### PR DESCRIPTION
I've added text direction support to the both Notus and Zefyr. It matches the behavior of Quill's rich text editor based on my tests.