### PR TITLE
issue-461: fixed basic toolbar visibility issue

### DIFF
--- a/packages/zefyr/lib/src/widgets/editor_toolbar.dart
+++ b/packages/zefyr/lib/src/widgets/editor_toolbar.dart
@@ -389,7 +389,7 @@ class ZefyrToolbar extends StatefulWidget implements PreferredSizeWidget {
   factory ZefyrToolbar.basic({Key key, @required ZefyrController controller, bool hideBoldButton=false, bool hideItalicButton=false, bool hideUnderLineButton=false, bool hideStrikeThrough=false, bool hideHeadingStyle=false, bool hideListNumbers=false, bool hideListBullets=false, bool hideCodeBlock=false, bool hideQuote=false, bool hideLink=false, bool hideHorizontalRule=false}) {
     return ZefyrToolbar(key: key, children: [
       Visibility(
-        visible: hideBoldButton,
+        visible: !hideBoldButton,
         child: ToggleStyleButton(
           attribute: NotusAttribute.bold,
           icon: Icons.format_bold,
@@ -398,7 +398,7 @@ class ZefyrToolbar extends StatefulWidget implements PreferredSizeWidget {
       ),
       SizedBox(width: 1),
       Visibility(
-        visible: hideItalicButton,
+        visible: !hideItalicButton,
         child: ToggleStyleButton(
           attribute: NotusAttribute.italic,
           icon: Icons.format_italic,
@@ -407,7 +407,7 @@ class ZefyrToolbar extends StatefulWidget implements PreferredSizeWidget {
       ),
       SizedBox(width: 1),
       Visibility(
-        visible: hideUnderLineButton,
+        visible: !hideUnderLineButton,
         child: ToggleStyleButton(
           attribute: NotusAttribute.underline,
           icon: Icons.format_underline,
@@ -416,18 +416,18 @@ class ZefyrToolbar extends StatefulWidget implements PreferredSizeWidget {
       ),
       SizedBox(width: 1),
       Visibility(
-        visible: hideStrikeThrough,
+        visible: !hideStrikeThrough,
         child: ToggleStyleButton(
           attribute: NotusAttribute.strikethrough,
           icon: Icons.format_strikethrough,
           controller: controller,
         ),
       ),
-      Visibility(visible: hideHeadingStyle, child: VerticalDivider(indent: 16, endIndent: 16, color: Colors.grey.shade400)),
-      Visibility(visible: hideHeadingStyle, child: SelectHeadingStyleButton(controller: controller)),
+      Visibility(visible: !hideHeadingStyle, child: VerticalDivider(indent: 16, endIndent: 16, color: Colors.grey.shade400)),
+      Visibility(visible: !hideHeadingStyle, child: SelectHeadingStyleButton(controller: controller)),
       VerticalDivider(indent: 16, endIndent: 16, color: Colors.grey.shade400),
       Visibility(
-        visible: hideListNumbers,
+        visible: !hideListNumbers,
         child: ToggleStyleButton(
           attribute: NotusAttribute.block.numberList,
           controller: controller,
@@ -435,7 +435,7 @@ class ZefyrToolbar extends StatefulWidget implements PreferredSizeWidget {
         ),
       ),
       Visibility(
-        visible: hideListBullets,
+        visible: !hideListBullets,
         child: ToggleStyleButton(
           attribute: NotusAttribute.block.bulletList,
           controller: controller,
@@ -443,7 +443,7 @@ class ZefyrToolbar extends StatefulWidget implements PreferredSizeWidget {
         ),
       ),
       Visibility(
-        visible: hideCodeBlock,
+        visible: !hideCodeBlock,
         child: ToggleStyleButton(
           attribute: NotusAttribute.block.code,
           controller: controller,
@@ -454,17 +454,17 @@ class ZefyrToolbar extends StatefulWidget implements PreferredSizeWidget {
           visible: !hideListNumbers && !hideListBullets && !hideCodeBlock,
           child: VerticalDivider(indent: 16, endIndent: 16, color: Colors.grey.shade400)),
       Visibility(
-        visible: hideQuote,
+        visible: !hideQuote,
         child: ToggleStyleButton(
           attribute: NotusAttribute.block.quote,
           controller: controller,
           icon: Icons.format_quote,
         ),
       ),
-      Visibility(visible: hideQuote, child: VerticalDivider(indent: 16, endIndent: 16, color: Colors.grey.shade400)),
-      Visibility(visible: hideLink, child: LinkStyleButton(controller: controller)),
+      Visibility(visible: !hideQuote, child: VerticalDivider(indent: 16, endIndent: 16, color: Colors.grey.shade400)),
+      Visibility(visible: !hideLink, child: LinkStyleButton(controller: controller)),
       Visibility(
-        visible: hideHorizontalRule,
+        visible: !hideHorizontalRule,
         child: InsertEmbedButton(
           controller: controller,
           icon: Icons.horizontal_rule,


### PR DESCRIPTION
This is a candidate fix for https://github.com/memspace/zefyr/issues/461.

Named parameters: `hideBoldButton`, `hideItalicButton`, etc..  were incorrectly used in the basic Zefyr Toolbar constructor. 