### PR TITLE
Fix a bug that empty delta would be treated as retain and cause cursor to not move

### DIFF
--- a/packages/notus/lib/src/document.dart
+++ b/packages/notus/lib/src/document.dart
@@ -105,7 +105,7 @@ class NotusDocument {
   /// produces a change event with its source set to [ChangeSource.local].
   ///
   /// Returns an instance of [Delta] actually composed into this document.
-  Delta insert(int index, Object data) {
+  Delta insert(int index, Object data, {int replaceLength = 0}) {
     assert(index >= 0);
     if (data is String) {
       if (data.isEmpty) return Delta();
@@ -114,7 +114,7 @@ class NotusDocument {
       data = (data as EmbeddableObject).toJson();
     }
 
-    final change = _heuristics.applyInsertRules(this, index, data);
+    final change = _heuristics.applyInsertRules(this, index, replaceLength, data);
     compose(change, ChangeSource.local);
     return change;
   }
@@ -155,7 +155,7 @@ class NotusDocument {
     // We have to insert before applying delete rules
     // Otherwise delete would be operating on stale document snapshot.
     if (dataIsNotEmpty) {
-      delta = insert(index + length, data);
+      delta = insert(index, data, replaceLength: length);
     }
 
     if (length > 0) {

--- a/packages/notus/lib/src/document/node.dart
+++ b/packages/notus/lib/src/document/node.dart
@@ -208,7 +208,9 @@ abstract class ContainerNode<T extends Node> extends Node {
   /// which points at the same character position in the document as the
   /// original [offset].
   LookupResult lookup(int offset, {bool inclusive = false}) {
-    assert(offset >= 0 && offset <= length);
+    if (offset < 0 || offset > length) {
+      return LookupResult(null, 0);
+    }
 
     for (final node in children) {
       final length = node.length;

--- a/packages/notus/lib/src/heuristics.dart
+++ b/packages/notus/lib/src/heuristics.dart
@@ -63,11 +63,13 @@ class NotusHeuristics {
 
   /// Applies heuristic rules to specified insert operation based on current
   /// state of Notus [document].
-  Delta applyInsertRules(NotusDocument document, int index, Object data) {
+  Delta applyInsertRules(NotusDocument document, int index, int replaceLength, Object data, ) {
     final delta = document.toDelta();
     for (var rule in insertRules) {
-      final result = rule.apply(delta, index, data);
-      if (result != null) return result..trim();
+      final result = rule.apply(delta, index, replaceLength, data);
+      if (result != null) {
+        return result..trim();
+      }
     }
     throw StateError('Failed to apply insert heuristic rules: none applied.');
   }

--- a/packages/notus/lib/src/heuristics.dart
+++ b/packages/notus/lib/src/heuristics.dart
@@ -63,7 +63,7 @@ class NotusHeuristics {
 
   /// Applies heuristic rules to specified insert operation based on current
   /// state of Notus [document].
-  Delta applyInsertRules(NotusDocument document, int index, int replaceLength, Object data, ) {
+  Delta applyInsertRules(NotusDocument document, int index, int replaceLength, Object data) {
     final delta = document.toDelta();
     for (var rule in insertRules) {
       final result = rule.apply(delta, index, replaceLength, data);

--- a/packages/notus/test/heuristics/insert_rules_test.dart
+++ b/packages/notus/test/heuristics/insert_rules_test.dart
@@ -14,7 +14,7 @@ void main() {
 
     test('applies change as-is', () {
       final doc = Delta()..insert('Document\n');
-      final actual = rule.apply(doc, 8, '!');
+      final actual = rule.apply(doc, 8, 0, '!');
       final expected = Delta()
         ..retain(8)
         ..insert('!');
@@ -27,7 +27,7 @@ void main() {
 
     test('skips at the beginning of a document', () {
       final doc = Delta()..insert('One\n');
-      final actual = rule.apply(doc, 0, '\n');
+      final actual = rule.apply(doc, 0, 0, '\n');
       expect(actual, isNull);
     });
 
@@ -37,7 +37,7 @@ void main() {
         ..insert('\n', ul)
         ..insert('Three')
         ..insert('\n', ul);
-      final actual = rule.apply(doc, 8, '\n');
+      final actual = rule.apply(doc, 8, 0, '\n');
       final expected = Delta()
         ..retain(8)
         ..insert('\n', ul);
@@ -53,7 +53,7 @@ void main() {
       final doc = Delta()
         ..insert('Hello world')
         ..insert('\n', NotusAttribute.h1.toJson());
-      final actual = rule.apply(doc, 11, '\n');
+      final actual = rule.apply(doc, 11, 0, '\n');
       expect(actual, isNotNull);
       final expected = Delta()
         ..retain(11)
@@ -64,7 +64,7 @@ void main() {
 
     test('applies without style reset if not needed', () {
       final doc = Delta()..insert('Hello world\n');
-      final actual = rule.apply(doc, 11, '\n');
+      final actual = rule.apply(doc, 11, 0, '\n');
       expect(actual, isNotNull);
       final expected = Delta()
         ..retain(11)
@@ -74,7 +74,7 @@ void main() {
 
     test('applies at the beginning of a document', () {
       final doc = Delta()..insert('\n', NotusAttribute.h1.toJson());
-      final actual = rule.apply(doc, 0, '\n');
+      final actual = rule.apply(doc, 0, 0, '\n');
       expect(actual, isNotNull);
       final expected = Delta()
         ..insert('\n', NotusAttribute.h1.toJson())
@@ -86,7 +86,7 @@ void main() {
       final style = NotusAttribute.ul.toJson();
       style.addAll(NotusAttribute.h1.toJson());
       final doc = Delta()..insert('Hello world')..insert('\n', style);
-      final actual = rule.apply(doc, 11, '\n');
+      final actual = rule.apply(doc, 11, 0, '\n');
       expect(actual, isNotNull);
       final expected = Delta()
         ..retain(11)
@@ -99,7 +99,7 @@ void main() {
       final doc = Delta()
         ..insert('Hello \nworld!\nMore lines here.')
         ..insert('\n', NotusAttribute.h2.toJson());
-      final actual = rule.apply(doc, 30, '\n');
+      final actual = rule.apply(doc, 30, 0, '\n');
       expect(actual, isNotNull);
       final expected = Delta()
         ..retain(30)
@@ -120,7 +120,7 @@ void main() {
         ..insert('\n', ul)
         ..insert('Item 2')
         ..insert('\n\n', ul);
-      final actual = rule.apply(doc, 14, '\n');
+      final actual = rule.apply(doc, 14, 0, '\n');
       expect(actual, isNotNull);
       final expected = Delta()
         ..retain(14)
@@ -131,14 +131,14 @@ void main() {
     test('applies only on empty line', () {
       final ul = NotusAttribute.ul.toJson();
       final doc = Delta()..insert('Item 1')..insert('\n', ul);
-      final actual = rule.apply(doc, 6, '\n');
+      final actual = rule.apply(doc, 6, 0, '\n');
       expect(actual, isNull);
     });
 
     test('applies at the beginning of a document', () {
       final ul = NotusAttribute.ul.toJson();
       final doc = Delta()..insert('\n', ul);
-      final actual = rule.apply(doc, 0, '\n');
+      final actual = rule.apply(doc, 0, 0, '\n');
       expect(actual, isNotNull);
       final expected = Delta()..retain(1, NotusAttribute.block.unset.toJson());
       expect(actual, expected);
@@ -147,14 +147,14 @@ void main() {
     test('ignores non-empty line at the beginning of a document', () {
       final ul = NotusAttribute.ul.toJson();
       final doc = Delta()..insert('Text')..insert('\n', ul);
-      final actual = rule.apply(doc, 0, '\n');
+      final actual = rule.apply(doc, 0, 0, '\n');
       expect(actual, isNull);
     });
 
     test('ignores empty lines in the middle of a block', () {
       final ul = NotusAttribute.ul.toJson();
       final doc = Delta()..insert('Line1')..insert('\n\n\n\n', ul);
-      final actual = rule.apply(doc, 7, '\n');
+      final actual = rule.apply(doc, 7, 0, '\n');
       expect(actual, isNull);
     });
   });
@@ -166,7 +166,7 @@ void main() {
         ..insert('Doc with ')
         ..insert('bold', bold)
         ..insert(' text');
-      final actual = rule.apply(doc, 13, 'er');
+      final actual = rule.apply(doc, 13, 0, 'er');
       final expected = Delta()
         ..retain(13)
         ..insert('er', bold);
@@ -175,7 +175,7 @@ void main() {
 
     test('apply at the beginning of a document', () {
       final doc = Delta()..insert('Doc with ');
-      final actual = rule.apply(doc, 0, 'A ');
+      final actual = rule.apply(doc, 0, 0, 'A ');
       expect(actual, isNull);
     });
   });
@@ -186,7 +186,7 @@ void main() {
 
     test('apply simple', () {
       final doc = Delta()..insert('Doc with link https://example.com');
-      final actual = rule.apply(doc, 33, ' ');
+      final actual = rule.apply(doc, 33, 0, ' ');
       final expected = Delta()
         ..retain(14)
         ..retain(19, link)
@@ -196,13 +196,13 @@ void main() {
 
     test('applies only to insert of single space', () {
       final doc = Delta()..insert('Doc with link https://example.com');
-      final actual = rule.apply(doc, 33, '/');
+      final actual = rule.apply(doc, 33, 0, '/');
       expect(actual, isNull);
     });
 
     test('applies for links at the beginning of line', () {
       final doc = Delta()..insert('Doc with link\nhttps://example.com');
-      final actual = rule.apply(doc, 33, ' ');
+      final actual = rule.apply(doc, 33, 0, ' ');
       final expected = Delta()
         ..retain(14)
         ..retain(19, link)
@@ -214,7 +214,7 @@ void main() {
       final doc = Delta()
         ..insert('Doc with link\n')
         ..insert('https://example.com', link);
-      final actual = rule.apply(doc, 33, ' ');
+      final actual = rule.apply(doc, 33, 0, ' ');
       expect(actual, isNull);
     });
   });
@@ -228,7 +228,7 @@ void main() {
         ..insert('\n', ul)
         ..insert('Three')
         ..insert('\n', ul);
-      final actual = rule.apply(doc, 8, 'also \n');
+      final actual = rule.apply(doc, 8, 0, 'also \n');
       final expected = Delta()
         ..retain(8)
         ..insert('also ')
@@ -243,7 +243,7 @@ void main() {
         ..insert('\n\n', ul)
         ..insert('Three')
         ..insert('\n', ul);
-      final actual = rule.apply(doc, 12, '\n');
+      final actual = rule.apply(doc, 12, 0, '\n');
       final expected = Delta()
         ..retain(12)
         ..insert('\n', ul);
@@ -256,7 +256,7 @@ void main() {
         ..insert('\n\n', ul)
         ..insert('Three')
         ..insert('\n', ul);
-      final actual = rule.apply(doc, 8, '111\n222\n333');
+      final actual = rule.apply(doc, 8, 0, '111\n222\n333');
       final expected = Delta()
         ..retain(8)
         ..insert('111')
@@ -277,7 +277,7 @@ void main() {
         ..insert('\n', quote_h1)
         ..insert('Three')
         ..insert('\n', quote);
-      final actual = rule.apply(doc, 8, '111\n');
+      final actual = rule.apply(doc, 8, 0, '111\n');
       final expected = Delta()
         ..retain(8)
         ..insert('111')
@@ -298,7 +298,7 @@ void main() {
         ..insert('\n')
         ..insert('Three')
         ..insert('\n');
-      final actual = rule.apply(doc, 12, BlockEmbed.horizontalRule);
+      final actual = rule.apply(doc, 12, 0, BlockEmbed.horizontalRule);
       final expected = Delta()
         ..retain(12)
         ..insert(BlockEmbed.horizontalRule);
@@ -312,7 +312,7 @@ void main() {
         ..insert('embed here\n')
         ..insert('Three')
         ..insert('\n');
-      final actual = rule.apply(doc, 12, BlockEmbed.horizontalRule);
+      final actual = rule.apply(doc, 12, 0, BlockEmbed.horizontalRule);
       final expected = Delta()
         ..retain(12)
         ..insert(BlockEmbed.horizontalRule)
@@ -327,7 +327,7 @@ void main() {
         ..insert('embed here\n')
         ..insert('Three')
         ..insert('\n');
-      final actual = rule.apply(doc, 11, BlockEmbed.horizontalRule);
+      final actual = rule.apply(doc, 11, 0, BlockEmbed.horizontalRule);
       final expected = Delta()
         ..retain(11)
         ..insert('\n')
@@ -342,7 +342,7 @@ void main() {
         ..insert('embed here\n')
         ..insert('Three')
         ..insert('\n');
-      final actual = rule.apply(doc, 17, BlockEmbed.horizontalRule);
+      final actual = rule.apply(doc, 17, 0, BlockEmbed.horizontalRule);
       final expected = Delta()
         ..retain(17)
         ..insert('\n')

--- a/packages/notus/test/heuristics_test.dart
+++ b/packages/notus/test/heuristics_test.dart
@@ -23,7 +23,7 @@ void main() {
       );
 
       expect(() {
-        heuristics.applyInsertRules(doc, 0, 'a');
+        heuristics.applyInsertRules(doc, 0, 0, 'a');
       }, throwsStateError);
 
       expect(() {

--- a/packages/zefyr/lib/src/rendering/editable_box.dart
+++ b/packages/zefyr/lib/src/rendering/editable_box.dart
@@ -146,6 +146,7 @@ class RenderEditableContainerBox extends RenderBox
     List<RenderEditableBox> children,
     @required ContainerNode node,
     @required TextDirection textDirection,
+    @required double scrollBottomInset,
     @required EdgeInsetsGeometry padding,
   })  : assert(node != null),
         assert(textDirection != null),
@@ -153,6 +154,7 @@ class RenderEditableContainerBox extends RenderBox
         assert(padding.isNonNegative),
         _node = node,
         _textDirection = textDirection,
+        _scrollBottomInset = scrollBottomInset,
         _padding = padding {
     addAll(children);
   }
@@ -173,6 +175,16 @@ class RenderEditableContainerBox extends RenderBox
       return;
     }
     _textDirection = value;
+  }
+
+  double get scrollBottomInset => _scrollBottomInset;
+  double _scrollBottomInset;
+  set scrollBottomInset(double value) {
+    assert(value != null);
+    if (_scrollBottomInset == value) {
+      return;
+    }
+    _scrollBottomInset = value;
   }
 
   // Start padding implementation

--- a/packages/zefyr/lib/src/rendering/editable_text_block.dart
+++ b/packages/zefyr/lib/src/rendering/editable_text_block.dart
@@ -16,6 +16,7 @@ class RenderEditableTextBlock extends RenderEditableContainerBox
     List<RenderEditableBox> children,
     @required BlockNode node,
     @required TextDirection textDirection,
+    double scrollBottomInset,
     @required EdgeInsetsGeometry padding,
     @required Decoration decoration,
     ImageConfiguration configuration = ImageConfiguration.empty,
@@ -33,6 +34,7 @@ class RenderEditableTextBlock extends RenderEditableContainerBox
           children: children,
           node: node,
           textDirection: textDirection,
+          scrollBottomInset: scrollBottomInset,
           padding: padding.add(contentPadding),
         );
 

--- a/packages/zefyr/lib/src/rendering/editor.dart
+++ b/packages/zefyr/lib/src/rendering/editor.dart
@@ -314,7 +314,7 @@ class RenderEditor extends RenderEditableContainerBox
   void resetTapDownStatus() {
     _lastTapDownPosition = null;
   }
-  
+
   @override
   void handleTapDown(TapDownDetails details) {
     _lastTapDownPosition = details.globalPosition;

--- a/packages/zefyr/lib/src/rendering/editor.dart
+++ b/packages/zefyr/lib/src/rendering/editor.dart
@@ -98,6 +98,7 @@ class RenderEditor extends RenderEditableContainerBox
     @required TextSelection selection,
     @required LayerLink startHandleLayerLink,
     @required LayerLink endHandleLayerLink,
+    @required double scrollBottomInset,
     @required EdgeInsetsGeometry padding,
     TextSelectionChangedHandler onSelectionChanged,
     EdgeInsets floatingCursorAddedMargin =
@@ -115,6 +116,7 @@ class RenderEditor extends RenderEditableContainerBox
           children: children,
           node: document.root,
           textDirection: textDirection,
+          scrollBottomInset: scrollBottomInset,
           padding: padding,
         );
 
@@ -236,9 +238,10 @@ class RenderEditor extends RenderEditableContainerBox
       final caretTop = endpoints.single.point.dy -
           child.preferredLineHeight(childPosition) -
           kMargin +
-          offsetInViewport;
+          offsetInViewport +
+          scrollBottomInset;
       final caretBottom =
-          endpoints.single.point.dy + kMargin + offsetInViewport;
+          endpoints.single.point.dy + kMargin + offsetInViewport + scrollBottomInset;
       double dy;
       if (caretTop < scrollOffset) {
         dy = caretTop;

--- a/packages/zefyr/lib/src/rendering/editor.dart
+++ b/packages/zefyr/lib/src/rendering/editor.dart
@@ -311,6 +311,10 @@ class RenderEditor extends RenderEditableContainerBox
 
   Offset /*?*/ _lastTapDownPosition;
 
+  void resetTapDownStatus() {
+    _lastTapDownPosition = null;
+  }
+  
   @override
   void handleTapDown(TapDownDetails details) {
     _lastTapDownPosition = details.globalPosition;
@@ -416,11 +420,17 @@ class RenderEditor extends RenderEditableContainerBox
 
   @override
   void selectWord({@required SelectionChangedCause cause}) {
+    if (_lastTapDownPosition == null) {
+      return;
+    }
     selectWordsInRange(from: _lastTapDownPosition, cause: cause);
   }
 
   @override
   void selectPosition({@required SelectionChangedCause cause}) {
+    if (_lastTapDownPosition == null) {
+      return;
+    }
     selectPositionAt(from: _lastTapDownPosition, cause: cause);
   }
 

--- a/packages/zefyr/lib/src/widgets/controller.dart
+++ b/packages/zefyr/lib/src/widgets/controller.dart
@@ -82,7 +82,7 @@ class ZefyrController extends ChangeNotifier {
     _toggledStyles = NotusStyle();
 
     if (selection != null) {
-      if (delta == null) {
+      if (delta == null || delta.isEmpty) {
         _updateSelectionSilent(selection, source: ChangeSource.local);
       } else {
         // need to transform selection position in case actual delta

--- a/packages/zefyr/lib/src/widgets/controller.dart
+++ b/packages/zefyr/lib/src/widgets/controller.dart
@@ -11,6 +11,7 @@ List<String> _insertionToggleableStyleKeys = [
   NotusAttribute.italic.key,
   NotusAttribute.underline.key,
   NotusAttribute.strikethrough.key,
+  NotusAttribute.mark.key,
 ];
 
 class ZefyrController extends ChangeNotifier {

--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -176,6 +176,12 @@ class ZefyrEditor extends StatefulWidget {
   /// Defaults to [defaultZefyrEmbedBuilder].
   final ZefyrEmbedBuilder embedBuilder;
 
+  final bool Function(TapDownDetails details, TextPosition textPosition) onTapDown;
+  final bool Function(TapUpDetails details, TextPosition textPosition) onTapUp;
+  final bool Function(LongPressStartDetails details, TextPosition textPosition) onSingleLongTapStart;
+  final bool Function(LongPressMoveUpdateDetails details, TextPosition textPosition) onSingleLongTapMoveUpdate;
+  final bool Function(LongPressEndDetails details, TextPosition textPosition) onSingleLongTapEnd;
+
   const ZefyrEditor({
     Key key,
     @required this.controller,
@@ -195,6 +201,11 @@ class ZefyrEditor extends StatefulWidget {
     this.scrollPhysics,
     this.onLaunchUrl,
     this.embedBuilder = defaultZefyrEmbedBuilder,
+    this.onTapDown,
+    this.onTapUp,
+    this.onSingleLongTapStart,
+    this.onSingleLongTapMoveUpdate,
+    this.onSingleLongTapEnd,
   })  : assert(controller != null),
         super(key: key);
 
@@ -215,6 +226,46 @@ class _ZefyrEditorState extends State<ZefyrEditor>
 
   @override
   bool get selectionEnabled => widget.enableInteractiveSelection;
+
+   @override
+  bool overrideHandleTapDown(TapDownDetails details, TextPosition textPosition) {
+    if (widget.onTapDown == null) {
+      return false;
+    }
+    return widget.onTapDown(details, textPosition);
+  }
+
+  @override
+  bool overrideHandleTapUp(TapUpDetails details, TextPosition textPosition) {
+    if (widget.onTapUp == null) {
+      return false;
+    }
+    return widget.onTapUp(details, textPosition);
+  }
+
+  @override
+  bool overrideSingleLongTapStart(LongPressStartDetails details, TextPosition textPosition) {
+    if (widget.onSingleLongTapStart == null) {
+      return false;
+    }
+    return widget.onSingleLongTapStart(details, textPosition);
+  }
+
+  @override
+  bool overrideSingleLongTapMoveUpdate(LongPressMoveUpdateDetails details, TextPosition textPosition) {
+    if (widget.onSingleLongTapMoveUpdate == null) {
+      return false;
+    }
+    return widget.onSingleLongTapMoveUpdate(details, textPosition);
+  }
+
+  @override
+  bool overrideSingleLongTapEnd(LongPressEndDetails details, TextPosition textPosition) {
+    if (widget.onSingleLongTapEnd == null) {
+      return false;
+    }
+    return widget.onSingleLongTapEnd(details, textPosition);
+  }
 
   EditorTextSelectionGestureDetectorBuilder _selectionGestureDetectorBuilder;
 
@@ -343,6 +394,11 @@ class _ZefyrEditorSelectionGestureDetectorBuilder
 
   @override
   void onSingleLongTapMoveUpdate(LongPressMoveUpdateDetails details) {
+    if (_state.widget.onSingleLongTapMoveUpdate != null) {
+      if (_state.widget.onSingleLongTapMoveUpdate(details, renderEditor.getPositionForOffset(details.globalPosition))) {
+        return;
+      }
+    }
     if (delegate.selectionEnabled) {
       switch (Theme.of(_state.context).platform) {
         case TargetPlatform.iOS:
@@ -387,6 +443,11 @@ class _ZefyrEditorSelectionGestureDetectorBuilder
 
   @override
   void onSingleTapUp(TapUpDetails details) {
+    if (_state.widget.onTapUp != null) {
+      if (_state.widget.onTapUp(details, renderEditor.getPositionForOffset(details.globalPosition))) {
+        return;
+      }
+    }
     editor.hideToolbar();
 
     // TODO: Explore if we can forward tap up events to the TextSpan gesture detector
@@ -426,6 +487,11 @@ class _ZefyrEditorSelectionGestureDetectorBuilder
 
   @override
   void onSingleLongTapStart(LongPressStartDetails details) {
+    if (_state.widget.onSingleLongTapStart != null) {
+      if (_state.widget.onSingleLongTapStart(details, renderEditor.getPositionForOffset(details.globalPosition))) {
+        return;
+      }
+    }
     if (delegate.selectionEnabled) {
       switch (Theme.of(_state.context).platform) {
         case TargetPlatform.iOS:

--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -227,7 +227,7 @@ class _ZefyrEditorState extends State<ZefyrEditor>
   @override
   bool get selectionEnabled => widget.enableInteractiveSelection;
 
-   @override
+  @override
   bool overrideHandleTapDown(TapDownDetails details, TextPosition textPosition) {
     if (widget.onTapDown == null) {
       return false;

--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -81,6 +81,9 @@ class ZefyrEditor extends StatefulWidget {
   /// Set to `true` by default.
   final bool scrollable;
 
+  /// Additional inset to show cursor properly.
+  final double scrollBottomInset;
+
   /// Additional space around the content of this editor.
   final EdgeInsetsGeometry padding;
 
@@ -188,6 +191,7 @@ class ZefyrEditor extends StatefulWidget {
     this.focusNode,
     this.scrollController,
     this.scrollable = true,
+    this.scrollBottomInset = 0,
     this.padding = EdgeInsets.zero,
     this.autofocus = false,
     this.showCursor = true,
@@ -335,6 +339,7 @@ class _ZefyrEditorState extends State<ZefyrEditor>
       focusNode: widget.focusNode,
       scrollController: widget.scrollController,
       scrollable: widget.scrollable,
+      scrollBottomInset: widget.scrollBottomInset,
       padding: widget.padding,
       autofocus: widget.autofocus,
       showCursor: widget.showCursor,
@@ -520,6 +525,7 @@ class RawEditor extends StatefulWidget {
     @required this.focusNode,
     this.scrollController,
     this.scrollable = true,
+    this.scrollBottomInset = 0,
     this.padding = EdgeInsets.zero,
     this.autofocus = false,
     bool showCursor,
@@ -574,6 +580,9 @@ class RawEditor extends StatefulWidget {
   final ScrollController scrollController;
 
   final bool scrollable;
+
+  /// Additional inset to show cursor properly.
+  final double scrollBottomInset;
 
   /// Additional space around the editor contents.
   final EdgeInsetsGeometry padding;
@@ -1129,6 +1138,7 @@ class RawEditorState extends EditorState
           startHandleLayerLink: _startHandleLayerLink,
           endHandleLayerLink: _endHandleLayerLink,
           onSelectionChanged: _handleSelectionChanged,
+          scrollBottomInset: widget.scrollBottomInset,
           padding: widget.padding,
         ),
       ),
@@ -1252,6 +1262,7 @@ class _Editor extends MultiChildRenderObjectWidget {
     @required this.startHandleLayerLink,
     @required this.endHandleLayerLink,
     @required this.onSelectionChanged,
+    this.scrollBottomInset = 0,
     this.padding = EdgeInsets.zero,
   }) : super(key: key, children: children);
 
@@ -1262,6 +1273,7 @@ class _Editor extends MultiChildRenderObjectWidget {
   final LayerLink startHandleLayerLink;
   final LayerLink endHandleLayerLink;
   final TextSelectionChangedHandler onSelectionChanged;
+  final double scrollBottomInset;
   final EdgeInsetsGeometry padding;
 
   @override
@@ -1274,6 +1286,7 @@ class _Editor extends MultiChildRenderObjectWidget {
       startHandleLayerLink: startHandleLayerLink,
       endHandleLayerLink: endHandleLayerLink,
       onSelectionChanged: onSelectionChanged,
+      scrollBottomInset: scrollBottomInset,
       padding: padding,
     );
   }
@@ -1289,6 +1302,7 @@ class _Editor extends MultiChildRenderObjectWidget {
     renderObject.startHandleLayerLink = startHandleLayerLink;
     renderObject.endHandleLayerLink = endHandleLayerLink;
     renderObject.onSelectionChanged = onSelectionChanged;
+    renderObject.scrollBottomInset = scrollBottomInset;
     renderObject.padding = padding;
   }
 

--- a/packages/zefyr/lib/src/widgets/editor_selection_delegate_mixin.dart
+++ b/packages/zefyr/lib/src/widgets/editor_selection_delegate_mixin.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
-import 'package:notus/notus.dart';
 
 import 'editor.dart';
 

--- a/packages/zefyr/lib/src/widgets/editor_toolbar.dart
+++ b/packages/zefyr/lib/src/widgets/editor_toolbar.dart
@@ -7,11 +7,13 @@ const double kToolbarHeight = 56.0;
 
 class InsertEmbedButton extends StatelessWidget {
   final ZefyrController controller;
+  final Color fillColor;
   final IconData icon;
 
   const InsertEmbedButton({
     Key key,
     @required this.controller,
+    this.fillColor,
     @required this.icon,
   }) : super(key: key);
   @override
@@ -25,7 +27,7 @@ class InsertEmbedButton extends StatelessWidget {
         size: 18,
         color: Theme.of(context).iconTheme.color,
       ),
-      fillColor: Theme.of(context).canvasColor,
+      fillColor: fillColor,
       onPressed: () {
         final index = controller.selection.baseOffset;
         final length = controller.selection.extentOffset - index;
@@ -153,6 +155,7 @@ class _LinkDialogState extends State<_LinkDialog> {
 typedef ToggleStyleButtonBuilder = Widget Function(
   BuildContext context,
   NotusAttribute attribute,
+  Color fillColor,
   IconData icon,
   bool isToggled,
   VoidCallback onPressed,
@@ -162,6 +165,9 @@ typedef ToggleStyleButtonBuilder = Widget Function(
 class ToggleStyleButton extends StatefulWidget {
   /// The style attribute controlled by this button.
   final NotusAttribute attribute;
+
+  /// The fill color of the button
+  final Color fillColor;
 
   /// The icon representing the style [attribute].
   final IconData icon;
@@ -175,6 +181,7 @@ class ToggleStyleButton extends StatefulWidget {
   ToggleStyleButton({
     Key key,
     @required this.attribute,
+    this.fillColor,
     @required this.icon,
     @required this.controller,
     this.childBuilder = defaultToggleStyleButtonBuilder,
@@ -233,7 +240,7 @@ class _ToggleStyleButtonState extends State<ToggleStyleButton> {
         _selectionStyle.containsSame(NotusAttribute.block.code);
     final isEnabled =
         !isInCodeBlock || widget.attribute == NotusAttribute.block.code;
-    return widget.childBuilder(context, widget.attribute, widget.icon,
+    return widget.childBuilder(context, widget.attribute, widget.fillColor, widget.icon,
         _isToggled, isEnabled ? _toggleAttribute : null);
   }
 
@@ -250,6 +257,7 @@ class _ToggleStyleButtonState extends State<ToggleStyleButton> {
 Widget defaultToggleStyleButtonBuilder(
   BuildContext context,
   NotusAttribute attribute,
+  Color fillColor,
   IconData icon,
   bool isToggled,
   VoidCallback onPressed,
@@ -261,12 +269,12 @@ Widget defaultToggleStyleButtonBuilder(
           ? theme.primaryIconTheme.color
           : theme.iconTheme.color
       : theme.disabledColor;
-  final fillColor = isToggled ? theme.toggleableActiveColor : theme.canvasColor;
+  fillColor = isToggled ? theme.toggleableActiveColor : fillColor;
   return ZIconButton(
     highlightElevation: 0,
     hoverElevation: 0,
-    size: 32,
-    icon: Icon(icon, size: 18, color: iconColor),
+    size: 36,
+    icon: Icon(icon, size: 22, color: iconColor),
     fillColor: fillColor,
     onPressed: onPressed,
   );

--- a/packages/zefyr/lib/src/widgets/text_line.dart
+++ b/packages/zefyr/lib/src/widgets/text_line.dart
@@ -41,7 +41,7 @@ class TextLine extends StatelessWidget {
       textStyle: text.style,
       textDirection: textDirection,
       strutStyle: strutStyle,
-      locale: Localizations.localeOf(context, nullOk: true),
+      locale: Localizations.localeOf(context),
       child: RichText(
         text: buildText(context, node),
         textDirection: textDirection,

--- a/packages/zefyr/lib/src/widgets/text_line.dart
+++ b/packages/zefyr/lib/src/widgets/text_line.dart
@@ -115,6 +115,9 @@ class TextLine extends StatelessWidget {
     if (style.contains(NotusAttribute.strikethrough)) {
       result = _mergeTextStyleWithDecoration(result, theme.strikethrough);
     }
+    if (style.contains(NotusAttribute.mark)) {
+      result = _mergeTextStyleWithDecoration(result, theme.mark);
+    }
     return result;
   }
 

--- a/packages/zefyr/lib/src/widgets/text_selection.dart
+++ b/packages/zefyr/lib/src/widgets/text_selection.dart
@@ -354,6 +354,7 @@ class EditorTextSelectionOverlay {
           endpoints,
           selectionDelegate,
           clipboardStatus,
+          null
         ),
       ),
     );

--- a/packages/zefyr/lib/src/widgets/text_selection.dart
+++ b/packages/zefyr/lib/src/widgets/text_selection.dart
@@ -644,7 +644,7 @@ abstract class EditorTextSelectionGestureDetectorBuilderDelegate {
 
   /// Whether the user may select text in the textfield.
   bool get selectionEnabled;
-  
+
   bool overrideHandleTapDown(TapDownDetails details, TextPosition textPosition);
   bool overrideHandleTapUp(TapUpDetails details, TextPosition textPosition);
   bool overrideSingleLongTapStart(LongPressStartDetails details, TextPosition textPosition);

--- a/packages/zefyr/lib/src/widgets/text_selection.dart
+++ b/packages/zefyr/lib/src/widgets/text_selection.dart
@@ -644,6 +644,12 @@ abstract class EditorTextSelectionGestureDetectorBuilderDelegate {
 
   /// Whether the user may select text in the textfield.
   bool get selectionEnabled;
+  
+  bool overrideHandleTapDown(TapDownDetails details, TextPosition textPosition);
+  bool overrideHandleTapUp(TapUpDetails details, TextPosition textPosition);
+  bool overrideSingleLongTapStart(LongPressStartDetails details, TextPosition textPosition);
+  bool overrideSingleLongTapMoveUpdate(LongPressMoveUpdateDetails details, TextPosition textPosition);
+  bool overrideSingleLongTapEnd(LongPressEndDetails details, TextPosition textPosition);
 }
 
 /// Builds a [EditorTextSelectionGestureDetector] to wrap an [EditableText].
@@ -708,6 +714,10 @@ class EditorTextSelectionGestureDetectorBuilder {
   ///  * [EditorTextSelectionGestureDetector.onTapDown], which triggers this callback.
   @protected
   void onTapDown(TapDownDetails details) {
+    renderEditor.resetTapDownStatus();
+    if (delegate.overrideHandleTapDown(details, renderEditor.getPositionForOffset(details.globalPosition))) {
+      return;
+    }
     renderEditor.handleTapDown(details);
     // The selection overlay should only be shown when the user is interacting
     // through a touch screen (via either a finger or a stylus). A mouse shouldn't
@@ -773,6 +783,9 @@ class EditorTextSelectionGestureDetectorBuilder {
   ///    this callback.
   @protected
   void onSingleTapUp(TapUpDetails details) {
+    if (delegate.overrideHandleTapUp(details, renderEditor.getPositionForOffset(details.globalPosition))) {
+      return;
+    }
     if (delegate.selectionEnabled) {
       renderEditor.selectWordEdge(cause: SelectionChangedCause.tap);
     }
@@ -802,6 +815,9 @@ class EditorTextSelectionGestureDetectorBuilder {
   ///    this callback.
   @protected
   void onSingleLongTapStart(LongPressStartDetails details) {
+    if (delegate.overrideSingleLongTapStart(details, renderEditor.getPositionForOffset(details.globalPosition))) {
+      return;
+    }
     if (delegate.selectionEnabled) {
       renderEditor.selectPositionAt(
         from: details.globalPosition,
@@ -821,6 +837,9 @@ class EditorTextSelectionGestureDetectorBuilder {
   ///    triggers this callback.
   @protected
   void onSingleLongTapMoveUpdate(LongPressMoveUpdateDetails details) {
+    if (delegate.overrideSingleLongTapMoveUpdate(details, renderEditor.getPositionForOffset(details.globalPosition))) {
+      return;
+    }
     if (delegate.selectionEnabled) {
       renderEditor.selectPositionAt(
         from: details.globalPosition,
@@ -839,6 +858,9 @@ class EditorTextSelectionGestureDetectorBuilder {
   ///    callback.
   @protected
   void onSingleLongTapEnd(LongPressEndDetails details) {
+    if (delegate.overrideSingleLongTapEnd(details, renderEditor.getPositionForOffset(details.globalPosition))) {
+      return;
+    }
     if (shouldShowSelectionToolbar) editor.showToolbar();
   }
 

--- a/packages/zefyr/lib/src/widgets/theme.dart
+++ b/packages/zefyr/lib/src/widgets/theme.dart
@@ -74,6 +74,9 @@ class ZefyrThemeData {
   /// Style of strikethrough text.
   final TextStyle strikethrough;
 
+  /// Style of mark text.
+  final TextStyle mark;
+
   /// Style of links in text.
   final TextStyle link;
 
@@ -102,6 +105,7 @@ class ZefyrThemeData {
     this.italic,
     this.underline,
     this.strikethrough,
+    this.mark,
     this.link,
     this.paragraph,
     this.heading1,
@@ -140,6 +144,7 @@ class ZefyrThemeData {
       italic: TextStyle(fontStyle: FontStyle.italic),
       underline: TextStyle(decoration: TextDecoration.underline),
       strikethrough: TextStyle(decoration: TextDecoration.lineThrough),
+      mark: TextStyle(backgroundColor: Colors.lightGreenAccent),
       link: TextStyle(
         color: themeData.accentColor,
         decoration: TextDecoration.underline,
@@ -212,6 +217,7 @@ class ZefyrThemeData {
     TextStyle italic,
     TextStyle underline,
     TextStyle strikethrough,
+    TextStyle mark,
     TextStyle link,
     TextBlockTheme paragraph,
     TextBlockTheme heading1,
@@ -226,6 +232,7 @@ class ZefyrThemeData {
       italic: italic ?? this.italic,
       underline: underline ?? this.underline,
       strikethrough: strikethrough ?? this.strikethrough,
+      mark: mark ?? this.mark,
       link: link ?? this.link,
       paragraph: paragraph ?? this.paragraph,
       heading1: heading1 ?? this.heading1,
@@ -243,6 +250,7 @@ class ZefyrThemeData {
       italic: other.italic,
       underline: other.underline,
       strikethrough: other.strikethrough,
+      mark: other.mark,
       link: other.link,
       paragraph: other.paragraph,
       heading1: other.heading1,

--- a/packages/zefyr/lib/util.dart
+++ b/packages/zefyr/lib/util.dart
@@ -12,6 +12,9 @@ import 'package:quill_delta/quill_delta.dart';
 export 'src/fast_diff.dart';
 
 int getPositionDelta(Delta user, Delta actual) {
+  if (actual.isEmpty) {
+    return 0;
+  }
   final userIter = DeltaIterator(user);
   final actualIter = DeltaIterator(actual);
   var diff = 0;


### PR DESCRIPTION
If I have a BlockEmbed.image(imagePath), then in the next line has some text, then if I place the cursor at the beginning of the text and tap backspace, the cursor wouldn't go to the end of the BlockEmbed because in getPositionDelta the empty `actual` would be treated as `retain` and cause a diff + 1 https://github.com/memspace/zefyr/blob/646b3f6238bb1d9c78e1cd9f1b3fbe1d4f98b93f/packages/zefyr/lib/util.dart#L27 

I think both places should be guarded against empty op - let me know if I missed something!

Note that since `zefyr` repo has been inactive recently, I'll use my fork as my working in progress repo to fix issues I found along the way in my project, so let me know if you want to break PRs up.