### PR TITLE
Update quiver hashcode dependency

### DIFF
--- a/packages/notus/lib/src/document/attributes.dart
+++ b/packages/notus/lib/src/document/attributes.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import 'package:collection/collection.dart';
-import 'package:quiver_hashcode/hashcode.dart';
+import 'package:quiver/core.dart';
 
 /// Scope of a style attribute, defines context in which an attribute can be
 /// applied.

--- a/packages/notus/pubspec.yaml
+++ b/packages/notus/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   collection: ^1.14.6
   meta: ^1.1.0
   quill_delta: ^1.0.0
-  quiver_hashcode: ^2.0.0
+  quiver: ^2.0.0
 
 dev_dependencies:
   pedantic: ^1.0.0

--- a/packages/zefyr/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/zefyr/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 import FlutterMacOS
 import Foundation
 

--- a/packages/zefyr/lib/src/widgets/mode.dart
+++ b/packages/zefyr/lib/src/widgets/mode.dart
@@ -1,5 +1,5 @@
 import 'package:meta/meta.dart';
-import 'package:quiver_hashcode/hashcode.dart';
+import 'package:quiver/core.dart';
 
 /// Controls level of interactions allowed by Zefyr editor.
 ///

--- a/packages/zefyr/pubspec.yaml
+++ b/packages/zefyr/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   quill_delta: ^1.0.0
   notus: ^0.1.0
   meta: ^1.1.0
-  quiver_hashcode: ^2.0.0
+  quiver: ^2.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Development on the quiver_* subpackages has been discontinued in favour
of the main quiver package at https://github.com/~/quiver-dart. The
code itself is identical, but is more actively maintained.

This migrates to version 2.0.0 of quiver since version 3.0.0 has been
migrated to null-safety, which requires Dart SDK 2.12.0 or Flutter
2.0.0.