### PR TITLE
Removed meta package from Notus

### DIFF
--- a/packages/notus/pubspec.yaml
+++ b/packages/notus/pubspec.yaml
@@ -9,7 +9,6 @@ environment:
 
 dependencies:
   collection: ^1.15.0
-  meta: ^1.4.0
   quill_delta: ^3.0.0-nullsafety.0
   quiver: ^3.0.1
 


### PR DESCRIPTION
`meta` package is not used in Notus anymore after migrating to null safety.