### PR TITLE
Fix caret display when cursor on embed line

### DIFF
--- a/packages/zefyr/lib/src/rendering/embed_proxy.dart
+++ b/packages/zefyr/lib/src/rendering/embed_proxy.dart
@@ -31,7 +31,9 @@ class RenderEmbedProxy extends RenderProxyBox implements RenderContentProxyBox {
   @override
   Offset getOffsetForCaret(TextPosition position, Rect caretPrototype) {
     assert(position.offset == 0 || position.offset == 1);
-    return (position.offset == 0) ? Offset.zero : Offset(size.width, 0.0);
+    return (position.offset == 0)
+        ? Offset.zero
+        : Offset(size.width - caretPrototype.width, 0.0);
   }
 
   @override


### PR DESCRIPTION
When caret was at the end of a line with an embed, it was off displayed area, thus invisible to users

This fixes the issue