### PR TITLE
Example: Read-only: launch url

### DIFF
--- a/packages/zefyr/example/lib/src/read_only_view.dart
+++ b/packages/zefyr/example/lib/src/read_only_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 import 'package:zefyr/zefyr.dart';
 
 import 'scaffold.dart';
@@ -42,9 +43,17 @@ class _ReadOnlyViewState extends State<ReadOnlyView> {
           readOnly: !_edit,
           showCursor: _edit,
           padding: EdgeInsets.symmetric(horizontal: 8),
+          onLaunchUrl: _launchUrl,
         ),
       ),
     );
+  }
+
+  void _launchUrl(String url) async {
+    final result = await canLaunch(url);
+    if (result) {
+      await launch(url);
+    }
   }
 
   void _toggleEdit() {


### PR DESCRIPTION
Bring the same launch url behavior to the read-only page.