### PR TITLE
MouseCursor on links

### DIFF
--- a/packages/zefyr/lib/src/rendering/editable_text_line.dart
+++ b/packages/zefyr/lib/src/rendering/editable_text_line.dart
@@ -708,5 +708,17 @@ class RenderEditableTextLine extends RenderEditableBox {
     _cursorPainter.paint(context.canvas, effectiveOffset, position);
   }
 
+  @override
+  bool hitTestChildren(BoxHitTestResult result, {required Offset position}) {
+    if (body == null) return false;
+    final parentData = body!.parentData as BoxParentData;
+    return result.addWithPaintOffset(
+        offset: parentData.offset,
+        position: position,
+        hitTest: (BoxHitTestResult result, Offset position) {
+          return body!.hitTest(result, position: position);
+        });
+  }
+
 // End render box overrides
 }

--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -377,13 +377,8 @@ class _ZefyrEditorSelectionGestureDetectorBuilder
     final segment = segmentResult.node as LeafNode;
     if (segment.style.contains(NotusAttribute.link) &&
         editor!.widget.onLaunchUrl != null) {
-      if (editor!.widget.readOnly) {
-        editor!
-            .widget.onLaunchUrl!(segment.style.get(NotusAttribute.link)!.value);
-      } else {
-        // TODO: Implement a toolbar to display the URL and allow to launch it.
-        // editor.showToolbar();
-      }
+      editor!
+          .widget.onLaunchUrl!(segment.style.get(NotusAttribute.link)!.value);
     }
   }
 

--- a/packages/zefyr/lib/src/widgets/text_line.dart
+++ b/packages/zefyr/lib/src/widgets/text_line.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:notus/notus.dart';
 
@@ -64,9 +65,15 @@ class TextLine extends StatelessWidget {
     final segment = node as TextNode;
     final attrs = segment.style;
 
+    MouseCursor? cursor;
+    if (attrs.contains(NotusAttribute.link)) {
+      cursor = SystemMouseCursors.click;
+    }
+
     return TextSpan(
       text: segment.value,
       style: _getInlineTextStyle(attrs, theme),
+      mouseCursor: cursor,
     );
   }
 


### PR DESCRIPTION
This implements hitTestChildren for RenderEditableTextLine.

This also set the mouseCursor to "click" for links and always open links on click. :D
The previous behavior was hard to understand for a user. Some apps do it like this, because you probably want to open a link  more than you want to edit it. To edit: just remove it and make another one.
In anycase it seems like a good quickfix before we do something better.

In practice this forward events to RichText & (probably) embeds. 
We could use TextSpan gesture detector for handling clicks on link. Your call :)