### PR TITLE
EditableTextLine: fix a null safety issue

### DIFF
--- a/packages/zefyr/lib/src/widgets/editable_text_line.dart
+++ b/packages/zefyr/lib/src/widgets/editable_text_line.dart
@@ -159,7 +159,7 @@ class _RenderEditableTextLineElement extends RenderObjectElement {
         renderObject.leading = child as RenderBox?;
         break;
       case TextLineSlot.body:
-        renderObject.body = child as RenderContentProxyBox;
+        renderObject.body = child as RenderContentProxyBox?;
         break;
       case null:
         break;


### PR DESCRIPTION
Simple fix.

Was triggered when adding a new HR line.