### PR TITLE
Heuristics: supports setting block attribute based on the beginning of the line

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Zefyr Example (debug)",
+      "program": "packages/zefyr/example/lib/main.dart",
+      "request": "launch",
+      "type": "dart",
+    },
+    {
+      "name": "Zefyr Example (profile)",
+      "program": "packages/zefyr/example/lib/main.dart",
+      "request": "launch",
+      "type": "dart",
+      "flutterMode": "profile"
+    },
+    {
+      "name": "Zefyr Example (release)",
+      "program": "packages/zefyr/example/lib/main.dart",
+      "request": "launch",
+      "type": "dart",
+      "flutterMode": "release"
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,6 +20,18 @@
       "request": "launch",
       "type": "dart",
       "flutterMode": "release"
+    },
+    {
+      "name": "Dart Tests",
+      "program": "test",
+      "request": "launch",
+      "type": "dart",
+      // "args": ["--plain-name", "preserve line"],
+      // "args": ["--plain-name", "apply simple"],
+      // "args": ["--plain-name", "applies to lines in the middle"],
+      "args": ["--plain-name", "replace applies heuristic"],
+
+      "cwd": "packages/notus"
     }
   ]
 }

--- a/packages/notus/pubspec.yaml
+++ b/packages/notus/pubspec.yaml
@@ -16,3 +16,7 @@ dev_dependencies:
   pedantic: ^1.0.0
   test: ^1.10.0
   test_coverage: ^0.4.0
+
+dependency_overrides:
+  quill_delta:
+    path: ../../../quill-delta-dart

--- a/packages/zefyr/example/lib/src/read_only_view.dart
+++ b/packages/zefyr/example/lib/src/read_only_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 import 'package:zefyr/zefyr.dart';
 
 import 'scaffold.dart';
@@ -42,9 +43,17 @@ class _ReadOnlyViewState extends State<ReadOnlyView> {
           readOnly: !_edit,
           showCursor: _edit,
           padding: EdgeInsets.symmetric(horizontal: 8),
+          onLaunchUrl: _launchUrl,
         ),
       ),
     );
+  }
+
+  void _launchUrl(String url) async {
+    final result = await canLaunch(url);
+    if (result) {
+      await launch(url);
+    }
   }
 
   void _toggleEdit() {

--- a/packages/zefyr/example/pubspec.yaml
+++ b/packages/zefyr/example/pubspec.yaml
@@ -13,6 +13,8 @@ description: A new Flutter project.
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 version: 1.0.0+1
 
+publish_to: none
+
 environment:
   sdk: ">=2.9.0 <3.0.0"
 
@@ -32,9 +34,11 @@ dependencies:
   zefyr:
     path: ../
 
-#dependency_overrides:
-#  notus:
-#    path: ../../notus
+dependency_overrides:
+ notus:
+   path: ../../notus
+ quill_delta:
+   path: ../../../../quill-delta-dart
 
 dev_dependencies:
   flutter_test:

--- a/packages/zefyr/lib/src/rendering/editable_text_line.dart
+++ b/packages/zefyr/lib/src/rendering/editable_text_line.dart
@@ -708,5 +708,17 @@ class RenderEditableTextLine extends RenderEditableBox {
     _cursorPainter.paint(context.canvas, effectiveOffset, position);
   }
 
+  @override
+  bool hitTestChildren(BoxHitTestResult result, {required Offset position}) {
+    if (body == null) return false;
+    final parentData = body!.parentData as BoxParentData;
+    return result.addWithPaintOffset(
+        offset: parentData.offset,
+        position: position,
+        hitTest: (BoxHitTestResult result, Offset position) {
+          return body!.hitTest(result, position: position);
+        });
+  }
+
 // End render box overrides
 }

--- a/packages/zefyr/lib/src/rendering/editor.dart
+++ b/packages/zefyr/lib/src/rendering/editor.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 import 'package:notus/notus.dart';
 
 import '../widgets/selection_utils.dart';
@@ -95,7 +96,7 @@ abstract class RenderAbstractEditor {
 ///
 /// Children of [RenderEditor] must be instances of [RenderEditableBox].
 class RenderEditor extends RenderEditableContainerBox
-    implements RenderAbstractEditor {
+    implements RenderAbstractEditor, TextLayoutMetrics {
   RenderEditor({
     ViewportOffset? offset,
     List<RenderEditableBox>? children,
@@ -627,4 +628,37 @@ class RenderEditor extends RenderEditableContainerBox
     final boxParentData = targetChild.parentData as BoxParentData;
     return childLocalRect.shift(Offset(0, boxParentData.offset.dy));
   }
+
+  // Implements TextLayoutMetrics
+
+  @override
+  TextPosition getTextPositionBelow(TextPosition position) {
+    final targetChild = childAtPosition(position);
+    final localPosition = targetChild.globalToLocalPosition(position);
+    return targetChild.getPositionBelow(localPosition)!;
+  }
+
+  @override
+  TextPosition getTextPositionAbove(TextPosition position) {
+    final targetChild = childAtPosition(position);
+    final localPosition = targetChild.globalToLocalPosition(position);
+    return targetChild.getPositionAbove(localPosition)!;
+  }
+
+  @override
+  TextSelection getLineAtOffset(TextPosition position) {
+    final targetChild = childAtPosition(position);
+    final localPosition = targetChild.globalToLocalPosition(position);
+    final line = targetChild.getLineBoundary(localPosition);
+    return TextSelection(baseOffset: line.start, extentOffset: line.end);
+  }
+
+  @override
+  TextRange getWordBoundary(TextPosition position) {
+    final targetChild = childAtPosition(position);
+    final localPosition = targetChild.globalToLocalPosition(position);
+    return targetChild.getWordBoundary(localPosition);
+  }
+
+  // End of TextLayoutMetrics implementation
 }

--- a/packages/zefyr/lib/src/widgets/editable_text_line.dart
+++ b/packages/zefyr/lib/src/widgets/editable_text_line.dart
@@ -159,7 +159,7 @@ class _RenderEditableTextLineElement extends RenderObjectElement {
         renderObject.leading = child as RenderBox?;
         break;
       case TextLineSlot.body:
-        renderObject.body = child as RenderContentProxyBox;
+        renderObject.body = child as RenderContentProxyBox?;
         break;
       case null:
         break;

--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -378,13 +378,8 @@ class _ZefyrEditorSelectionGestureDetectorBuilder
     final segment = segmentResult.node as LeafNode;
     if (segment.style.contains(NotusAttribute.link) &&
         editor!.widget.onLaunchUrl != null) {
-      if (editor!.widget.readOnly) {
-        editor!
-            .widget.onLaunchUrl!(segment.style.get(NotusAttribute.link)!.value);
-      } else {
-        // TODO: Implement a toolbar to display the URL and allow to launch it.
-        // editor.showToolbar();
-      }
+      editor!
+          .widget.onLaunchUrl!(segment.style.get(NotusAttribute.link)!.value);
     }
   }
 

--- a/packages/zefyr/lib/src/widgets/editor_toolbar.dart
+++ b/packages/zefyr/lib/src/widgets/editor_toolbar.dart
@@ -399,8 +399,11 @@ class ZefyrToolbar extends StatefulWidget implements PreferredSizeWidget {
       bool hideCodeBlock = false,
       bool hideQuote = false,
       bool hideLink = false,
-      bool hideHorizontalRule = false}) {
+      bool hideHorizontalRule = false,
+      List<Widget> prepend = const <Widget>[],
+      List<Widget> append = const <Widget>[]}) {
     return ZefyrToolbar(key: key, children: [
+      ...prepend,
       Visibility(
         visible: !hideBoldButton,
         child: ToggleStyleButton(
@@ -493,6 +496,7 @@ class ZefyrToolbar extends StatefulWidget implements PreferredSizeWidget {
           icon: Icons.horizontal_rule,
         ),
       ),
+      ...append,
     ]);
   }
 

--- a/packages/zefyr/lib/src/widgets/text_line.dart
+++ b/packages/zefyr/lib/src/widgets/text_line.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:notus/notus.dart';
 
@@ -64,9 +65,15 @@ class TextLine extends StatelessWidget {
     final segment = node as TextNode;
     final attrs = segment.style;
 
+    MouseCursor? cursor;
+    if (attrs.contains(NotusAttribute.link)) {
+      cursor = SystemMouseCursors.click;
+    }
+
     return TextSpan(
       text: segment.value,
       style: _getInlineTextStyle(attrs, theme),
+      mouseCursor: cursor,
     );
   }
 

--- a/packages/zefyr/pubspec.yaml
+++ b/packages/zefyr/pubspec.yaml
@@ -20,3 +20,9 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   pedantic: ^1.0.0
+
+dependency_overrides:
+  notus:
+    path: ../notus
+  quill_delta:
+    path: ../../../quill-delta-dart


### PR DESCRIPTION
This is posted to see if there is interest for that kind of features, otherwise it will live in my tree.

It supports '- ', '1. ', '> ', "'''", '# ', '## ', '### '

just type this at the beginning of a line to convert the line to this type of block.

There is still an issue with selection not being at the right spot afterward. I need to figure it out, this probably needs some kind of refactoring. I was thinking it would make sense to move the cursor after applying the rules to the last character described by the returned delta. 
Any idea?

Any comment on the feature?
