### PR TITLE
Toolbar.basic: allow to prepend / append buttons

### DIFF
--- a/packages/zefyr/lib/src/widgets/editor_toolbar.dart
+++ b/packages/zefyr/lib/src/widgets/editor_toolbar.dart
@@ -400,10 +400,10 @@ class ZefyrToolbar extends StatefulWidget implements PreferredSizeWidget {
       bool hideQuote = false,
       bool hideLink = false,
       bool hideHorizontalRule = false,
-      List<Widget> prepend = const <Widget>[],
-      List<Widget> append = const <Widget>[]}) {
+      List<Widget> leading = const <Widget>[],
+      List<Widget> trailing = const <Widget>[]}) {
     return ZefyrToolbar(key: key, children: [
-      ...prepend,
+      ...leading,
       Visibility(
         visible: !hideBoldButton,
         child: ToggleStyleButton(
@@ -496,7 +496,7 @@ class ZefyrToolbar extends StatefulWidget implements PreferredSizeWidget {
           icon: Icons.horizontal_rule,
         ),
       ),
-      ...append,
+      ...trailing,
     ]);
   }
 

--- a/packages/zefyr/lib/src/widgets/editor_toolbar.dart
+++ b/packages/zefyr/lib/src/widgets/editor_toolbar.dart
@@ -399,8 +399,11 @@ class ZefyrToolbar extends StatefulWidget implements PreferredSizeWidget {
       bool hideCodeBlock = false,
       bool hideQuote = false,
       bool hideLink = false,
-      bool hideHorizontalRule = false}) {
+      bool hideHorizontalRule = false,
+      List<Widget> prepend = const <Widget>[],
+      List<Widget> append = const <Widget>[]}) {
     return ZefyrToolbar(key: key, children: [
+      ...prepend,
       Visibility(
         visible: !hideBoldButton,
         child: ToggleStyleButton(
@@ -493,6 +496,7 @@ class ZefyrToolbar extends StatefulWidget implements PreferredSizeWidget {
           icon: Icons.horizontal_rule,
         ),
       ),
+      ...append,
     ]);
   }
 


### PR DESCRIPTION
simple solution to allow prepending or appending widgets on the basic toolbar.