### PR TITLE
Fix hitTestChildren for the editor

### DIFF
--- a/packages/zefyr/lib/src/rendering/editable_text_line.dart
+++ b/packages/zefyr/lib/src/rendering/editable_text_line.dart
@@ -708,5 +708,17 @@ class RenderEditableTextLine extends RenderEditableBox {
     _cursorPainter.paint(context.canvas, effectiveOffset, position);
   }
 
+  @override
+  bool hitTestChildren(BoxHitTestResult result, {required Offset position}) {
+    if (body == null) return false;
+    final parentData = body!.parentData as BoxParentData;
+    return result.addWithPaintOffset(
+        offset: parentData.offset,
+        position: position,
+        hitTest: (BoxHitTestResult result, Offset position) {
+          return body!.hitTest(result, position: position);
+        });
+  }
+
 // End render box overrides
 }


### PR DESCRIPTION
Fixes #426.

This is a cherry-pick from https://github.com/memspace/zefyr/pull/543

FYI: @cgestes , thanks again for submitting the fix!