### PR TITLE
Markdown block shortcuts

### DIFF
--- a/packages/notus/lib/src/heuristics/utils.dart
+++ b/packages/notus/lib/src/heuristics/utils.dart
@@ -1,0 +1,32 @@
+import 'dart:math' as math;
+
+import 'package:quill_delta/quill_delta.dart';
+
+/// Skips to the beginning of line containing position at specified [length]
+/// and returns contents of the line skipped so far.
+List<Operation> skipToLineAt(DeltaIterator iter, int length) {
+  assert(length > 0);
+
+  final prefix = <Operation>[];
+
+  var skipped = 0;
+  while (skipped < length && iter.hasNext) {
+    final opLength = iter.peekLength();
+    final skip = math.min(length - skipped, opLength);
+    final op = iter.next(skip);
+    if (op.data is! String) {
+      prefix.add(op);
+    } else {
+      var text = op.data as String;
+      var pos = text.lastIndexOf('\n');
+      if (pos == -1) {
+        prefix.add(op);
+      } else {
+        prefix.clear();
+        prefix.add(Operation.insert(text.substring(pos + 1), op.attributes));
+      }
+    }
+    skipped += op.length;
+  }
+  return prefix;
+}

--- a/packages/notus/test/heuristics/insert_rules_test.dart
+++ b/packages/notus/test/heuristics/insert_rules_test.dart
@@ -352,4 +352,36 @@ void main() {
       expect(actual, expected);
     });
   });
+
+  group('$MarkdownBlockShortcutsInsertRule', () {
+    final rule = MarkdownBlockShortcutsInsertRule();
+
+    test('apply markdown shortcut on single-line document', () {
+      final doc = Delta()..insert('#\n');
+      final actual = rule.apply(doc, 1, ' ');
+      final expected = Delta()
+        ..delete(1)
+        ..retain(1, NotusAttribute.h1.toJson());
+      expect(actual, expected);
+    });
+
+    test('ignores if already formatted with the same style', () {
+      final doc = Delta()
+        ..insert('#')
+        ..insert('\n', NotusAttribute.h1.toJson());
+      final actual = rule.apply(doc, 1, ' ');
+      expect(actual, isNull);
+    });
+
+    test('changes existing style', () {
+      final doc = Delta()
+        ..insert('##')
+        ..insert('\n', NotusAttribute.h1.toJson());
+      final actual = rule.apply(doc, 2, ' ');
+      final expected = Delta()
+        ..delete(2)
+        ..retain(1, NotusAttribute.h2.toJson());
+      expect(actual, expected);
+    });
+  });
 }


### PR DESCRIPTION
@cgestes I couldn't find your version in your PR (https://github.com/memspace/zefyr/pull/546) for some reason, so there was no commits to cherry-pick which would be authored by you. 

This implementation is basically the same as in the Gist I shared a while back, just adds some tests and docs.

Does not include the cursor position fix for Zefyr (will be submitted separately).