### PR TITLE
Markdown shortcuts code block formatting improvement

### DIFF
--- a/packages/notus/CHANGELOG.md
+++ b/packages/notus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Improved auto-formatting of code blocks from Markdown shortcuts ([#560](https://github.com/memspace/zefyr/pull/560))
+
 ## 1.0.0-dev.10.0
 
 * Activated the new Markdown block style shortcuts rule.

--- a/packages/notus/test/heuristics/insert_rules_test.dart
+++ b/packages/notus/test/heuristics/insert_rules_test.dart
@@ -383,5 +383,14 @@ void main() {
         ..retain(1, NotusAttribute.h2.toJson());
       expect(actual, expected);
     });
+
+    test('code block format does not require a space after the shortcut', () {
+      final doc = Delta()..insert('``\n');
+      final actual = rule.apply(doc, 2, '`');
+      final expected = Delta()
+        ..delete(2)
+        ..retain(1, NotusAttribute.code.toJson());
+      expect(actual, expected);
+    });
   });
 }


### PR DESCRIPTION
Adds a special case for code blocks to not require `space` character entered by the user after the shortcut (either ` ``` ` or `'''`). 

Applies the code block style immediately when the shortcut prefix itself is detected.