### PR TITLE
Fixed: Hide selection overlay for collapsed selection

### DIFF
--- a/packages/zefyr/lib/src/widgets/editor.dart
+++ b/packages/zefyr/lib/src/widgets/editor.dart
@@ -1072,7 +1072,7 @@ class RawEditorState extends EditorState
 
   void _updateOrDisposeSelectionOverlayIfNeeded() {
     if (_selectionOverlay != null) {
-      if (_hasFocus) {
+      if (_hasFocus && !textEditingValue.selection.isCollapsed) {
         _selectionOverlay!.update(textEditingValue);
       } else {
         _selectionOverlay!.dispose();


### PR DESCRIPTION
Steps to reproduce:

1. Run the example in iOS or Android 
2. Select some text, observe selection toolbar and handles appear
3. Press `delete` to delete the selected text

Expected: selection toolbar and handles should disappear

Actual: selection toolbar and handles still visible

@Amir-P @amantoux @cgestes I'd appreciate if any of you can validate the fix in your projects. From my testing this doesn't seem to break anything else.