### PR TITLE
Launch link improvements

### DIFF
--- a/packages/zefyr/CHANGELOG.md
+++ b/packages/zefyr/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 1.0.0-rc.3
 
-* Added keyboard shortcuts for bold, italic and underline styles.
+* Added keyboard shortcuts for bold, italic and underline styles. ([#580](https://github.com/memspace/zefyr/pull/580))
+* Launch URL improvements: allow launching links in editing mode ([#581](https://github.com/memspace/zefyr/pull/581))
+  - For desktop platforms: links launch on `Cmd` + `Click` (macOS) or `Ctrl` + `Click` (windows, linux)
+  - For mobile platforms: long-pressing a link shows a context menu with multiple actions (Open, Copy, Remove) for the user to choose from.
 
 ## 1.0.0-rc.2
 

--- a/packages/zefyr/example/lib/src/read_only_view.dart
+++ b/packages/zefyr/example/lib/src/read_only_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 import 'package:zefyr/zefyr.dart';
 
 import 'scaffold.dart';
@@ -44,9 +45,17 @@ class _ReadOnlyViewState extends State<ReadOnlyView> {
           readOnly: !_edit,
           showCursor: _edit,
           padding: const EdgeInsets.symmetric(horizontal: 8),
+          onLaunchUrl: _launchUrl,
         ),
       ),
     );
+  }
+
+  void _launchUrl(String url) async {
+    final result = await canLaunch(url);
+    if (result) {
+      await launch(url);
+    }
   }
 
   void _toggleEdit() {

--- a/packages/zefyr/lib/src/widgets/editable_text_block.dart
+++ b/packages/zefyr/lib/src/widgets/editable_text_block.dart
@@ -20,8 +20,10 @@ class EditableTextBlock extends StatelessWidget {
   final Color selectionColor;
   final bool enableInteractiveSelection;
   final bool hasFocus;
-  final EdgeInsets? contentPadding;
   final ZefyrEmbedBuilder embedBuilder;
+  final LinkActionPicker linkActionPicker;
+  final ValueChanged<String?>? onLaunchUrl;
+  final EdgeInsets? contentPadding;
 
   const EditableTextBlock({
     Key? key,
@@ -35,6 +37,8 @@ class EditableTextBlock extends StatelessWidget {
     required this.enableInteractiveSelection,
     required this.hasFocus,
     required this.embedBuilder,
+    required this.linkActionPicker,
+    this.onLaunchUrl,
     this.contentPadding,
   }) : super(key: key);
 
@@ -70,7 +74,11 @@ class EditableTextBlock extends StatelessWidget {
           devicePixelRatio: MediaQuery.of(context).devicePixelRatio,
           body: TextLine(
             node: line,
+            readOnly: readOnly,
+            controller: controller,
             embedBuilder: embedBuilder,
+            linkActionPicker: linkActionPicker,
+            onLaunchUrl: onLaunchUrl,
           ),
           cursorController: cursorController,
           selection: selection,

--- a/packages/zefyr/lib/src/widgets/editable_text_block.dart
+++ b/packages/zefyr/lib/src/widgets/editable_text_block.dart
@@ -7,6 +7,7 @@ import 'controller.dart';
 import 'cursor.dart';
 import 'editable_text_line.dart';
 import 'editor.dart';
+import 'link.dart';
 import 'text_line.dart';
 import 'theme.dart';
 

--- a/packages/zefyr/lib/src/widgets/keyboard_listener.dart
+++ b/packages/zefyr/lib/src/widgets/keyboard_listener.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class ZefyrPressedKeys extends ChangeNotifier {
+  static ZefyrPressedKeys of(BuildContext context) {
+    final widget =
+        context.dependOnInheritedWidgetOfExactType<_ZefyrPressedKeysAccess>();
+    return widget!.pressedKeys;
+  }
+
+  bool _metaPressed = false;
+  bool _controlPressed = false;
+
+  /// Whether meta key is currently pressed.
+  bool get metaPressed => _metaPressed;
+
+  /// Whether control key is currently pressed.
+  bool get controlPressed => _controlPressed;
+
+  void _updatePressedKeys(Set<LogicalKeyboardKey> pressedKeys) {
+    final meta = pressedKeys.contains(LogicalKeyboardKey.metaLeft) ||
+        pressedKeys.contains(LogicalKeyboardKey.metaRight);
+    final control = pressedKeys.contains(LogicalKeyboardKey.controlLeft) ||
+        pressedKeys.contains(LogicalKeyboardKey.controlRight);
+    if (_metaPressed != meta || _controlPressed != control) {
+      _metaPressed = meta;
+      _controlPressed = control;
+      notifyListeners();
+    }
+  }
+}
+
+class ZefyrKeyboardListener extends StatefulWidget {
+  final Widget child;
+  const ZefyrKeyboardListener({Key? key, required this.child})
+      : super(key: key);
+
+  @override
+  ZefyrKeyboardListenerState createState() => ZefyrKeyboardListenerState();
+}
+
+class ZefyrKeyboardListenerState extends State<ZefyrKeyboardListener> {
+  final ZefyrPressedKeys _pressedKeys = ZefyrPressedKeys();
+
+  bool _keyEvent(KeyEvent event) {
+    _pressedKeys
+        ._updatePressedKeys(HardwareKeyboard.instance.logicalKeysPressed);
+    return false;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    HardwareKeyboard.instance.addHandler(_keyEvent);
+    _pressedKeys
+        ._updatePressedKeys(HardwareKeyboard.instance.logicalKeysPressed);
+  }
+
+  @override
+  void dispose() {
+    HardwareKeyboard.instance.removeHandler(_keyEvent);
+    _pressedKeys.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _ZefyrPressedKeysAccess(
+      pressedKeys: _pressedKeys,
+      child: widget.child,
+    );
+  }
+}
+
+class _ZefyrPressedKeysAccess extends InheritedWidget {
+  final ZefyrPressedKeys pressedKeys;
+  const _ZefyrPressedKeysAccess({
+    Key? key,
+    required this.pressedKeys,
+    required Widget child,
+  }) : super(key: key, child: child);
+
+  @override
+  bool updateShouldNotify(covariant _ZefyrPressedKeysAccess oldWidget) {
+    return oldWidget.pressedKeys != pressedKeys;
+  }
+}

--- a/packages/zefyr/lib/src/widgets/link.dart
+++ b/packages/zefyr/lib/src/widgets/link.dart
@@ -3,16 +3,34 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:notus/notus.dart';
 
-import '../rendering/editor.dart';
-import 'text_line.dart';
+/// List of possible actions returned from [LinkActionPickerDelegate].
+enum LinkMenuAction {
+  /// Launch the link
+  launch,
 
-Future<LinkMenuAction> defaultShowLinkActionsMenu(BuildContext context,
-    String link, Node linkNode, RenderEditor renderEditor) async {
+  /// Copy to clipboard
+  copy,
+
+  /// Remove link style attribute
+  remove,
+
+  /// No-op
+  none,
+}
+
+/// Used internally by Zefyr widget layer.
+typedef LinkActionPicker = Future<LinkMenuAction> Function(Node linkNode);
+
+typedef LinkActionPickerDelegate = Future<LinkMenuAction> Function(
+    BuildContext context, String link);
+
+Future<LinkMenuAction> defaultLinkActionPickerDelegate(
+    BuildContext context, String link) async {
   switch (defaultTargetPlatform) {
     case TargetPlatform.iOS:
       return _showCupertinoLinkMenu(context, link);
     case TargetPlatform.android:
-      return _showMaterialMenu(context, link, linkNode, renderEditor);
+      return _showMaterialMenu(context, link);
     default:
       assert(false,
           'defaultShowLinkActionsMenu not supposed to be invoked for $defaultTargetPlatform');
@@ -89,8 +107,8 @@ class _CupertinoAction extends StatelessWidget {
   }
 }
 
-Future<LinkMenuAction> _showMaterialMenu(BuildContext context, String link,
-    Node linkNode, RenderEditor renderEditor) async {
+Future<LinkMenuAction> _showMaterialMenu(
+    BuildContext context, String link) async {
   final result = await showModalBottomSheet<LinkMenuAction>(
     context: context,
     builder: (ctx) {

--- a/packages/zefyr/lib/src/widgets/link.dart
+++ b/packages/zefyr/lib/src/widgets/link.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:notus/notus.dart';
+
+import '../rendering/editor.dart';
+import 'text_line.dart';
+
+Future<LinkMenuAction> defaultShowLinkActionsMenu(BuildContext context,
+    String link, Node linkNode, RenderEditor renderEditor) async {
+  switch (defaultTargetPlatform) {
+    case TargetPlatform.iOS:
+      return _showCupertinoLinkMenu(context, link);
+    case TargetPlatform.android:
+      return _showMaterialMenu(context, link, linkNode, renderEditor);
+    default:
+      assert(false,
+          'defaultShowLinkActionsMenu not supposed to be invoked for $defaultTargetPlatform');
+      return LinkMenuAction.none;
+  }
+}
+
+Future<LinkMenuAction> _showCupertinoLinkMenu(
+    BuildContext context, String link) async {
+  final result = await showCupertinoModalPopup<LinkMenuAction>(
+    context: context,
+    builder: (ctx) {
+      return CupertinoActionSheet(
+        title: Text(link),
+        actions: [
+          _CupertinoAction(
+            title: 'Open',
+            icon: Icons.language_sharp,
+            onPressed: () => Navigator.of(context).pop(LinkMenuAction.launch),
+          ),
+          _CupertinoAction(
+            title: 'Copy',
+            icon: Icons.copy_sharp,
+            onPressed: () => Navigator.of(context).pop(LinkMenuAction.copy),
+          ),
+          _CupertinoAction(
+            title: 'Remove',
+            icon: Icons.link_off_sharp,
+            onPressed: () => Navigator.of(context).pop(LinkMenuAction.remove),
+          ),
+        ],
+      );
+    },
+  );
+  return result ?? LinkMenuAction.none;
+}
+
+class _CupertinoAction extends StatelessWidget {
+  final String title;
+  final IconData icon;
+  final VoidCallback onPressed;
+  const _CupertinoAction({
+    Key? key,
+    required this.title,
+    required this.icon,
+    required this.onPressed,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return CupertinoActionSheetAction(
+      onPressed: onPressed,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8.0),
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(
+                title,
+                textAlign: TextAlign.start,
+                style: TextStyle(color: theme.colorScheme.onSurface),
+              ),
+            ),
+            Icon(
+              icon,
+              size: theme.iconTheme.size,
+              color: theme.colorScheme.onSurface.withOpacity(0.75),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+Future<LinkMenuAction> _showMaterialMenu(BuildContext context, String link,
+    Node linkNode, RenderEditor renderEditor) async {
+  final result = await showModalBottomSheet<LinkMenuAction>(
+    context: context,
+    builder: (ctx) {
+      return Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _MaterialAction(
+            title: 'Open',
+            icon: Icons.language_sharp,
+            onPressed: () => Navigator.of(context).pop(LinkMenuAction.launch),
+          ),
+          _MaterialAction(
+            title: 'Copy',
+            icon: Icons.copy_sharp,
+            onPressed: () => Navigator.of(context).pop(LinkMenuAction.copy),
+          ),
+          _MaterialAction(
+            title: 'Remove',
+            icon: Icons.link_off_sharp,
+            onPressed: () => Navigator.of(context).pop(LinkMenuAction.remove),
+          ),
+        ],
+      );
+    },
+  );
+
+  return result ?? LinkMenuAction.none;
+}
+
+class _MaterialAction extends StatelessWidget {
+  final String title;
+  final IconData icon;
+  final VoidCallback onPressed;
+
+  const _MaterialAction({
+    Key? key,
+    required this.title,
+    required this.icon,
+    required this.onPressed,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListTile(
+      leading: Icon(
+        icon,
+        size: theme.iconTheme.size,
+        color: theme.colorScheme.onSurface.withOpacity(0.75),
+      ),
+      title: Text(title),
+      onTap: onPressed,
+    );
+  }
+}

--- a/packages/zefyr/lib/src/widgets/text_line.dart
+++ b/packages/zefyr/lib/src/widgets/text_line.dart
@@ -4,19 +4,15 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:notus/notus.dart';
-import 'package:zefyr/src/widgets/controller.dart';
 
+import 'controller.dart';
 import 'editable_text_line.dart';
 import 'editor.dart';
 import 'embed_proxy.dart';
 import 'keyboard_listener.dart';
+import 'link.dart';
 import 'rich_text_proxy.dart';
 import 'theme.dart';
-
-
-enum LinkMenuAction { launch, copy, remove, none }
-
-typedef LinkActionPicker = Future<LinkMenuAction> Function(Node linkNode);
 
 /// Line of text in Zefyr editor.
 ///

--- a/packages/zefyr/lib/src/widgets/text_line.dart
+++ b/packages/zefyr/lib/src/widgets/text_line.dart
@@ -1,37 +1,134 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:notus/notus.dart';
+import 'package:zefyr/src/widgets/controller.dart';
 
 import 'editable_text_line.dart';
 import 'editor.dart';
 import 'embed_proxy.dart';
+import 'keyboard_listener.dart';
 import 'rich_text_proxy.dart';
 import 'theme.dart';
+
+
+enum LinkMenuAction { launch, copy, remove, none }
+
+typedef LinkActionPicker = Future<LinkMenuAction> Function(Node linkNode);
 
 /// Line of text in Zefyr editor.
 ///
 /// This widget allows to render non-editable line of rich text, but can be
 /// wrapped with [EditableTextLine] which adds editing features.
-class TextLine extends StatelessWidget {
+class TextLine extends StatefulWidget {
   /// Line of text represented by this widget.
   final LineNode node;
+  final bool readOnly;
+  final ZefyrController controller;
   final ZefyrEmbedBuilder embedBuilder;
+  final ValueChanged<String?>? onLaunchUrl;
+  final LinkActionPicker linkActionPicker;
 
   const TextLine({
     Key? key,
     required this.node,
+    required this.readOnly,
+    required this.controller,
     required this.embedBuilder,
+    required this.onLaunchUrl,
+    required this.linkActionPicker,
   }) : super(key: key);
+
+  @override
+  State<TextLine> createState() => _TextLineState();
+}
+
+class _TextLineState extends State<TextLine> {
+  bool _metaOrControlPressed = false;
+
+  UniqueKey _richTextKey = UniqueKey();
+
+  final _linkRecognizers = <Node, GestureRecognizer>{};
+
+  ZefyrPressedKeys? _pressedKeys;
+
+  void _pressedKeysChanged() {
+    final newValue = _pressedKeys!.metaPressed || _pressedKeys!.controlPressed;
+    if (_metaOrControlPressed != newValue) {
+      setState(() {
+        _metaOrControlPressed = newValue;
+        _richTextKey = UniqueKey();
+      });
+    }
+  }
+
+  bool get isDesktop => {
+        TargetPlatform.macOS,
+        TargetPlatform.linux,
+        TargetPlatform.windows
+      }.contains(defaultTargetPlatform);
+
+  bool get canLaunchLinks {
+    if (widget.onLaunchUrl == null) return false;
+    // In readOnly mode users can launch links by simply tapping (clicking) on them
+    if (widget.readOnly) return true;
+
+    // In editing mode it depends on the platform:
+
+    // Desktop platforms (macos, linux, windows): only allow Meta(Control)+Click combinations
+    if (isDesktop) {
+      return _metaOrControlPressed;
+    }
+    // Mobile platforms (ios, android): always allow but we install a
+    // long-press handler instead of a tap one. LongPress is followed by a
+    // context menu with actions.
+    return true;
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_pressedKeys == null) {
+      _pressedKeys = ZefyrPressedKeys.of(context);
+      _pressedKeys!.addListener(_pressedKeysChanged);
+    } else {
+      _pressedKeys!.removeListener(_pressedKeysChanged);
+      _pressedKeys = ZefyrPressedKeys.of(context);
+      _pressedKeys!.addListener(_pressedKeysChanged);
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant TextLine oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.readOnly != widget.readOnly) {
+      _richTextKey = UniqueKey();
+      _linkRecognizers.forEach((key, value) {
+        value.dispose();
+      });
+      _linkRecognizers.clear();
+    }
+  }
+
+  @override
+  void dispose() {
+    _pressedKeys?.removeListener(_pressedKeysChanged);
+    _linkRecognizers.forEach((key, value) => value.dispose());
+    _linkRecognizers.clear();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
-
-    if (node.hasEmbed) {
-      final embed = node.children.single as EmbedNode;
-      return EmbedProxy(child: embedBuilder(context, embed));
+    if (widget.node.hasEmbed) {
+      final embed = widget.node.children.single as EmbedNode;
+      return EmbedProxy(child: widget.embedBuilder(context, embed));
     }
-    final text = buildText(context, node);
-    final textAlign = getTextAlign(node);
+    final text = buildText(context, widget.node);
+    final textAlign = getTextAlign(widget.node);
     final strutStyle =
         StrutStyle.fromTextStyle(text.style!, forceStrutHeight: true);
     return RichTextProxy(
@@ -40,6 +137,7 @@ class TextLine extends StatelessWidget {
       strutStyle: strutStyle,
       locale: Localizations.maybeLocaleOf(context),
       child: RichText(
+        key: _richTextKey,
         text: text,
         textAlign: textAlign,
         strutStyle: strutStyle,
@@ -74,16 +172,86 @@ class TextLine extends StatelessWidget {
   TextSpan _segmentToTextSpan(Node segment, ZefyrThemeData theme) {
     final text = segment as TextNode;
     final attrs = text.style;
-
+    final isLink = attrs.contains(NotusAttribute.link);
     return TextSpan(
       text: text.value,
-      style: _getInlineTextStyle(attrs, node.style, theme),
+      style: _getInlineTextStyle(attrs, widget.node.style, theme),
+      recognizer: isLink && canLaunchLinks ? _getRecognizer(segment) : null,
+      mouseCursor: isLink && canLaunchLinks ? SystemMouseCursors.click : null,
     );
+  }
+
+  GestureRecognizer _getRecognizer(Node segment) {
+    if (_linkRecognizers.containsKey(segment)) {
+      return _linkRecognizers[segment]!;
+    }
+
+    if (isDesktop || widget.readOnly) {
+      _linkRecognizers[segment] = TapGestureRecognizer()
+        ..onTap = () => _tapLink(segment);
+    } else {
+      _linkRecognizers[segment] = LongPressGestureRecognizer()
+        ..onLongPress = () => _longPressLink(segment);
+    }
+    return _linkRecognizers[segment]!;
+  }
+
+  void _tapLink(Node segment) {
+    final link = (segment as StyledNode).style.get(NotusAttribute.link)!.value;
+    widget.onLaunchUrl!(link);
+  }
+
+  void _longPressLink(Node segment) async {
+    final link = (segment as StyledNode).style.get(NotusAttribute.link)!.value!;
+    final action = await widget.linkActionPicker(segment);
+    switch (action) {
+      case LinkMenuAction.launch:
+        widget.onLaunchUrl!(link);
+        break;
+      case LinkMenuAction.copy:
+        // ignore: unawaited_futures
+        Clipboard.setData(ClipboardData(text: link));
+        break;
+      case LinkMenuAction.remove:
+        final range = _getLinkRange(segment);
+        widget.controller.formatText(
+            range.start, range.end - range.start, NotusAttribute.link.unset);
+        break;
+      case LinkMenuAction.none:
+        break;
+    }
+  }
+
+  TextRange _getLinkRange(Node segment) {
+    int start = segment.documentOffset;
+    int length = segment.length;
+    var prev = segment.previous as StyledNode?;
+    final linkAttr = (segment as StyledNode).style.get(NotusAttribute.link)!;
+    while (prev != null) {
+      if (prev.style.containsSame(linkAttr)) {
+        start = prev.documentOffset;
+        length += prev.length;
+        prev = prev.previous as StyledNode?;
+      } else {
+        break;
+      }
+    }
+
+    var next = segment.next as StyledNode?;
+    while (next != null) {
+      if (next.style.containsSame(linkAttr)) {
+        length += next.length;
+        next = next.next as StyledNode?;
+      } else {
+        break;
+      }
+    }
+    return TextRange(start: start, end: start + length);
   }
 
   TextStyle _getParagraphTextStyle(NotusStyle style, ZefyrThemeData theme) {
     var textStyle = const TextStyle();
-    final heading = node.style.get(NotusAttribute.heading);
+    final heading = widget.node.style.get(NotusAttribute.heading);
     if (heading == NotusAttribute.heading.level1) {
       textStyle = textStyle.merge(theme.heading1.style);
     } else if (heading == NotusAttribute.heading.level2) {

--- a/packages/zefyr/lib/zefyr.dart
+++ b/packages/zefyr/lib/zefyr.dart
@@ -15,5 +15,6 @@ export 'src/widgets/cursor.dart';
 export 'src/widgets/editor.dart';
 export 'src/widgets/editor_toolbar.dart';
 export 'src/widgets/field.dart';
+export 'src/widgets/link.dart' show LinkActionPickerDelegate, LinkMenuAction;
 export 'src/widgets/text_line.dart';
 export 'src/widgets/theme.dart';


### PR DESCRIPTION
Allows launching links in editing mode, where:

* For desktop platforms: links launch on `Cmd` + `Click` (macOS) or `Ctrl` + `Click` (windows, linux)
* For mobile platforms: long-pressing a link shows a context menu with multiple actions (Open, Copy, Remove) for the user to choose from.

WIP