### PR TITLE
ZefyrShortcuts fix for italics ctrl-i on windows bug

### DIFF
--- a/packages/zefyr/lib/src/widgets/shortcuts.dart
+++ b/packages/zefyr/lib/src/widgets/shortcuts.dart
@@ -35,7 +35,7 @@ class ZefyrShortcuts extends Shortcuts {
     SingleActivator(LogicalKeyboardKey.keyB, control: true):
         ToggleBoldStyleIntent(),
     SingleActivator(LogicalKeyboardKey.keyI, control: true):
-        ToggleBoldStyleIntent(),
+        ToggleItalicStyleIntent(),
     SingleActivator(LogicalKeyboardKey.keyU, control: true):
         ToggleUnderlineStyleIntent(),
   };


### PR DESCRIPTION
One-line fix for italics shortcut bug in windows group of shortcuts.